### PR TITLE
operator[] support, the right way

### DIFF
--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -27,103 +27,103 @@ namespace sol {
 template <typename Table, typename Key>
 struct proxy {
 private:
-	Table& tbl;
-	Key& key;
+    Table& tbl;
+    Key& key;
 
 public:
 
-	template <typename T>
-	proxy( Table& table, T&& key ) : tbl( table ), key( std::forward<T>( key ) ) {
+    template <typename T>
+    proxy(Table& table, T&& key) : tbl(table), key(std::forward<T>(key)) {
 
-	}
+    }
 
-	template<typename T>
-	T get( ) const {
-		return tbl.get<T>( key );
-	}
+    template<typename T>
+    T get() const {
+        return tbl.get<T>(key);
+    }
 
-	template<typename T>
-	proxy& set( T&& item ) {
-		tbl.set( key, std::forward<T>( item ) );
-		return *this;
-	}
+    template<typename T>
+    proxy& set(T&& item) {
+        tbl.set(key, std::forward<T>(item));
+        return *this;
+    }
 
-	template<typename... Args>
-	proxy& set_function( Args&&... args ) {
-		tbl.set_function( key, std::forward<Args>( args )... );
-		return *this;
-	}
+    template<typename... Args>
+    proxy& set_function(Args&&... args) {
+        tbl.set_function(key, std::forward<Args>(args)...);
+        return *this;
+    }
 
-	template<typename U>
-	EnableIf<Function<Unqualified<U>>> operator=( U&& other ) {
-		tbl.set_function( key, std::forward<U>( other ) );
-	}
+    template<typename U>
+    EnableIf<Function<Unqualified<U>>> operator=(U&& other) {
+        tbl.set_function(key, std::forward<U>(other));
+    }
 
-	template<typename U>
-	DisableIf<Function<Unqualified<U>>> operator=( U&& other ) {
-		tbl.set( key, std::forward<U>( other ) );
-	}
+    template<typename U>
+    DisableIf<Function<Unqualified<U>>> operator=(U&& other) {
+        tbl.set(key, std::forward<U>(other));
+    }
 
-	operator nil_t ( ) const {
-		return get<nil_t>( );
-	}
+    operator nil_t () const {
+        return get<nil_t>();
+    }
 
-	operator object( ) const {
-		return get<object>( );
-	}
+    operator object() const {
+        return get<object>();
+    }
 
-	operator function( ) const {
-		return get<function>( );
-	}
+    operator function() const {
+        return get<function>();
+    }
 
-	operator std::string( ) const {
-		return get<std::string>( );
-	}
+    operator std::string() const {
+        return get<std::string>();
+    }
 
-	template <typename T = void>
-	operator bool( ) const {
-		return get<bool>( );
-	}
+    template <typename T = void>
+    operator bool() const {
+        return get<bool>();
+    }
 
-	template <typename T = void>
-	operator double( ) const {
-		return get<double>( );
-	}
+    template <typename T = void>
+    operator double() const {
+        return get<double>();
+    }
 
-	template <typename T = void>
-	operator float( ) const {
-		return get<float>( );
-	}
+    template <typename T = void>
+    operator float() const {
+        return get<float>();
+    }
 
-	template <typename T = void>
-	operator int( ) const {
-		return get<int>( );
-	}
+    template <typename T = void>
+    operator int() const {
+        return get<int>();
+    }
 
-	template<typename... Ret, typename... Args>
-	typename multi_return<Ret...>::type call( Args&&... args ) {
-		return tbl.get<function>(key)(types<Ret...>(), std::forward<Args>( args )...);
-	}
+    template<typename... Ret, typename... Args>
+    typename multi_return<Ret...>::type call(Args&&... args) {
+        return tbl.get<function>(key)(types<Ret...>(), std::forward<Args>(args)...);
+    }
 };
 
 template <typename Table, typename Key, typename T>
-inline bool operator== ( T&& left, const proxy<Table, Key>& right ) {
-	return left == right.template get<Decay<T>>( );
+inline bool operator== (T&& left, const proxy<Table, Key>& right) {
+    return left == right.template get<Decay<T>>();
 }
 
 template <typename Table, typename Key, typename T>
-inline bool operator== ( const proxy<Table, Key>& right, T&& left ) {
-	return right.template get<Decay<T>>( ) == left;
+inline bool operator== (const proxy<Table, Key>& right, T&& left) {
+    return right.template get<Decay<T>>() == left;
 }
 
 template <typename Table, typename Key, typename T>
-inline bool operator!= ( T&& left, const proxy<Table, Key>& right ) {
-	return right.template get<Decay<T>>( ) != left;
+inline bool operator!= (T&& left, const proxy<Table, Key>& right) {
+    return right.template get<Decay<T>>() != left;
 }
 
 template <typename Table, typename Key, typename T>
-inline bool operator!= ( const proxy<Table, Key>& right, T&& left ) {
-	return right.template get<Decay<T>>( ) != left;
+inline bool operator!= (const proxy<Table, Key>& right, T&& left) {
+    return right.template get<Decay<T>>() != left;
 }
 
 } // sol

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -208,7 +208,7 @@ inline int push_user(lua_State* L, T& item) {
 namespace detail {
 template<typename T, std::size_t... I>
 inline void push_tuple(lua_State* L, indices<I...>, T&& tuplen) {
-    using swallow = char[ 1 + sizeof...(I) ];
+    using swallow = char[1 + sizeof...(I)];
     swallow {'\0', (sol::stack::push(L, std::get<I>(tuplen)), '\0')... };
 }
 

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -175,13 +175,13 @@ public:
     }
 
     template <typename T>
-    proxy<table, T> operator[]( T&& key ) {
-	    return global[ std::forward<T>(key) ];
+    proxy<table, T> operator[](T&& key) {
+        return global[std::forward<T>(key)];
     }
 
     template <typename T>
-    proxy<const table, T> operator[]( T&& key ) const {
-	    return global[ std::forward<T>( key ) ];
+    proxy<const table, T> operator[](T&& key) const {
+        return global[std::forward<T>(key)];
     }
 };
 } // sol

--- a/sol/table.hpp
+++ b/sol/table.hpp
@@ -120,13 +120,13 @@ public:
     }
 
     template <typename T>
-    proxy<table, T> operator[]( T&& key ) {
-	    return proxy<table, T>( *this, std::forward<T>( key ) );
+    proxy<table, T> operator[](T&& key) {
+        return proxy<table, T>(*this, std::forward<T>(key));
     }
 
     template <typename T>
-    proxy<const table, T> operator[]( T&& key ) const {
-	    return proxy<const table, T>( *this, std::forward<T>( key ) );
+    proxy<const table, T> operator[](T&& key) const {
+        return proxy<const table, T>(*this, std::forward<T>(key));
     }
 
 private:
@@ -182,7 +182,7 @@ private:
         void* userobjdata = static_cast<void*>(detail::get_ptr(obj));
         lua_CFunction freefunc = &static_object_lua_func<Decay<TObj>, TFx>::call;
         const char* freefuncname = fkey.c_str();
-        const luaL_Reg funcreg[ 2 ] = {
+        const luaL_Reg funcreg[2] = {
             { freefuncname, freefunc },
             { nullptr, nullptr }
         };
@@ -204,7 +204,7 @@ private:
         Decay<TFx> target(std::forward<TFx>(fx));
         lua_CFunction freefunc = &static_lua_func<TFx>::call;
         const char* freefuncname = fkey.c_str();
-        const luaL_Reg funcreg[ 2 ] = {
+        const luaL_Reg funcreg[2] = {
             { freefuncname, freefunc },
             { nullptr, nullptr }
         };
@@ -229,7 +229,7 @@ private:
         lua_CFunction freefunc = &lua_func::call;
         const char* freefuncname = fkey.c_str();
         const char* metatablename = metakey.c_str();
-        const luaL_Reg funcreg[ 2 ] = {
+        const luaL_Reg funcreg[2] = {
             { freefuncname, freefunc },
             { nullptr, nullptr }
         };

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -62,20 +62,20 @@ struct is_function_impl : std::is_function<typename std::remove_pointer<T>::type
 
 template<typename T>
 struct is_function_impl<T, true> {
-	using yes = char;
-	using no = struct { char s[ 2 ]; };
+    using yes = char;
+    using no = struct { char s[2]; };
 
-	struct F { void operator()( ); };
-	struct Derived : T, F { };
-	template<typename U, U> struct Check;
+    struct F { void operator()(); };
+    struct Derived : T, F { };
+    template<typename U, U> struct Check;
 
-	template<typename V>
-	static no test( Check<void ( F::* )( ), &V::operator()>* );
+    template<typename V>
+    static no test(Check<void (F::*)(), &V::operator()>*);
 
-	template<typename>
-	static yes test( ... );
+    template<typename>
+    static yes test(...);
 
-	static const bool value = sizeof( test<Derived>( 0 ) ) == sizeof( yes );
+    static const bool value = sizeof(test<Derived>(0)) == sizeof(yes);
 };
 } // detail
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("simple/call_lambda", "A C++ lambda is exposed to lua and called") {
 
     int x = 0;
 
-    lua.set_function("foo", [ &x ] { x = 1; });
+    lua.set_function("foo", [&x] { x = 1; });
 
     lua.script("foo()");
 
@@ -117,33 +117,33 @@ TEST_CASE("advanced/get_and_call", "Checks for lambdas returning values after a 
     const static std::tuple<int, float, double, std::string> heh_tuple = std::make_tuple(1, 6.28f, 3.14, std::string("heh"));
     sol::state lua;
 
-    REQUIRE_NOTHROW(lua.set_function("a", [ ] { return 42; }));
+    REQUIRE_NOTHROW(lua.set_function("a", [] { return 42; }));
     REQUIRE(lua.get<sol::function>("a").call<int>() == 42);
     
-    REQUIRE_NOTHROW(lua.set_function("b", [ ] { return 42u; }));
+    REQUIRE_NOTHROW(lua.set_function("b", [] { return 42u; }));
     REQUIRE(lua.get<sol::function>("b").call<unsigned int>() == 42u);
 
-    REQUIRE_NOTHROW(lua.set_function("c", [ ] { return 3.14; }));
+    REQUIRE_NOTHROW(lua.set_function("c", [] { return 3.14; }));
     REQUIRE(lua.get<sol::function>("c").call<double>() == 3.14);
 
-    REQUIRE_NOTHROW(lua.set_function("d", [ ] { return 6.28f; }));
+    REQUIRE_NOTHROW(lua.set_function("d", [] { return 6.28f; }));
     REQUIRE(lua.get<sol::function>("d").call<float>() == 6.28f);
 
-    REQUIRE_NOTHROW(lua.set_function("e", [ ] { return "lol"; }));
+    REQUIRE_NOTHROW(lua.set_function("e", [] { return "lol"; }));
     REQUIRE(lua.get<sol::function>("e").call<std::string>() == lol);
 
-    REQUIRE_NOTHROW(lua.set_function("f", [ ] { return true; }));
+    REQUIRE_NOTHROW(lua.set_function("f", [] { return true; }));
     REQUIRE(lua.get<sol::function>("f").call<bool>());
 
-    REQUIRE_NOTHROW(lua.set_function("g", [ ] { return std::string("str"); }));
+    REQUIRE_NOTHROW(lua.set_function("g", [] { return std::string("str"); }));
     REQUIRE(lua.get<sol::function>("g").call<std::string>() == str);
 
-    REQUIRE_NOTHROW(lua.set_function("h", [ ] { }));
+    REQUIRE_NOTHROW(lua.set_function("h", [] { }));
     REQUIRE_NOTHROW(lua.get<sol::function>("h").call());
 
-    REQUIRE_NOTHROW(lua.set_function("i", [ ] { return sol::nil; }));
+    REQUIRE_NOTHROW(lua.set_function("i", [] { return sol::nil; }));
     REQUIRE(lua.get<sol::function>("i").call<sol::nil_t>() == sol::nil);
-    REQUIRE_NOTHROW(lua.set_function("j", [ ] { return std::make_tuple(1, 6.28f, 3.14, std::string("heh")); }));
+    REQUIRE_NOTHROW(lua.set_function("j", [] { return std::make_tuple(1, 6.28f, 3.14, std::string("heh")); }));
     REQUIRE((lua.get<sol::function>("j").call<int, float, double, std::string>() == heh_tuple));
 }
 
@@ -152,33 +152,33 @@ TEST_CASE("advanced/operator[]_calls", "Checks for lambdas returning values usin
     const static std::tuple<int, float, double, std::string> heh_tuple = std::make_tuple(1, 6.28f, 3.14, std::string("heh"));
     sol::state lua;
 
-    REQUIRE_NOTHROW(lua.set_function("a", [ ] { return 42; }));
+    REQUIRE_NOTHROW(lua.set_function("a", [] { return 42; }));
     REQUIRE(lua["a"].call<int>() == 42);
     
-    REQUIRE_NOTHROW(lua.set_function("b", [ ] { return 42u; }));
+    REQUIRE_NOTHROW(lua.set_function("b", [] { return 42u; }));
     REQUIRE(lua["b"].call<unsigned int>() == 42u);
 
-    REQUIRE_NOTHROW(lua.set_function("c", [ ] { return 3.14; }));
+    REQUIRE_NOTHROW(lua.set_function("c", [] { return 3.14; }));
     REQUIRE(lua["c"].call<double>() == 3.14);
 
-    REQUIRE_NOTHROW(lua.set_function("d", [ ] { return 6.28f; }));
+    REQUIRE_NOTHROW(lua.set_function("d", [] { return 6.28f; }));
     REQUIRE(lua["d"].call<float>() == 6.28f);
 
-    REQUIRE_NOTHROW(lua.set_function("e", [ ] { return "lol"; }));
+    REQUIRE_NOTHROW(lua.set_function("e", [] { return "lol"; }));
     REQUIRE(lua["e"].call<std::string>() == lol);
 
-    REQUIRE_NOTHROW(lua.set_function("f", [ ] { return true; }));
+    REQUIRE_NOTHROW(lua.set_function("f", [] { return true; }));
     REQUIRE(lua["f"].call<bool>());
 
-    REQUIRE_NOTHROW(lua.set_function("g", [ ] { return std::string("str"); }));
+    REQUIRE_NOTHROW(lua.set_function("g", [] { return std::string("str"); }));
     REQUIRE(lua["g"].call<std::string>() == str);
 
-    REQUIRE_NOTHROW(lua.set_function("h", [ ] { }));
+    REQUIRE_NOTHROW(lua.set_function("h", [] { }));
     REQUIRE_NOTHROW(lua["h"].call());
 
-    REQUIRE_NOTHROW(lua.set_function("i", [ ] { return sol::nil; }));
+    REQUIRE_NOTHROW(lua.set_function("i", [] { return sol::nil; }));
     REQUIRE(lua["i"].call<sol::nil_t>() == sol::nil);
-    REQUIRE_NOTHROW(lua.set_function("j", [ ] { return std::make_tuple(1, 6.28f, 3.14, std::string("heh")); }));
+    REQUIRE_NOTHROW(lua.set_function("j", [] { return std::make_tuple(1, 6.28f, 3.14, std::string("heh")); }));
     REQUIRE((lua["j"].call<int, float, double, std::string>() == heh_tuple));
 }
 
@@ -186,7 +186,7 @@ TEST_CASE("advanced/call_lambdas", "A C++ lambda is exposed to lua and called") 
     sol::state lua;
 
     int x = 0;
-    lua.set_function("set_x", [ &] (int new_x) {
+    lua.set_function("set_x", [&] (int new_x) {
         x = new_x;
         return 0;
     });
@@ -216,16 +216,16 @@ TEST_CASE("tables/variables", "Check if tables and variables work as intended") 
 TEST_CASE("tables/functions_variables", "Check if tables and function calls work as intended") {
     sol::state lua;
     lua.open_libraries(sol::lib::base, sol::lib::os);
-    auto run_script = [ ] (sol::state& lua) -> void {
+    auto run_script = [] (sol::state& lua) -> void {
         lua.script("assert(os.fun() == \"test\")");
     };
 
     lua.get<sol::table>("os").set_function("fun",
-        [ ] () {
+        [] () {
             std::cout << "stateless lambda()" << std::endl;
             return "test";
         }
-    );
+   );
     REQUIRE_NOTHROW(run_script(lua));
 
     lua.get<sol::table>("os").set_function("fun", &free_function);
@@ -239,11 +239,11 @@ TEST_CASE("tables/functions_variables", "Check if tables and function calls work
     // stateful lambda: non-convertible, unoptomizable
     int breakit = 50;
     lua.get<sol::table>("os").set_function("fun",
-        [ &breakit ] () {
+        [&breakit] () {
         std::cout << "stateless lambda()" << std::endl;
         return "test";
     }
-    );
+   );
     REQUIRE_NOTHROW(run_script(lua));
 
     // r-value, cannot optomize
@@ -256,12 +256,12 @@ TEST_CASE("tables/functions_variables", "Check if tables and function calls work
     REQUIRE_NOTHROW(run_script(lua));
 }
 
-TEST_CASE("functions/return_order_and_multi_get", "Check if return order is in the same reading order specified in Lua" ) {
+TEST_CASE("functions/return_order_and_multi_get", "Check if return order is in the same reading order specified in Lua") {
     const static std::tuple<int, int, int> triple = std::make_tuple(10, 11, 12);
     sol::state lua;
-    lua.set_function( "f", [ ] { 
-        return std::make_tuple( 10, 11, 12 ); 
-    } );
+    lua.set_function("f", [] { 
+        return std::make_tuple(10, 11, 12); 
+    });
     lua.script("function g() return 10, 11, 12 end\nx,y,z = g()");
     auto tcpp = lua.get<sol::function>("f").call<int, int, int>();
     auto tlua = lua.get<sol::function>("g").call<int, int, int>();
@@ -301,7 +301,7 @@ TEST_CASE("tables/operator[]", "Check if operator[] retrieval and setting works 
     REQUIRE_NOTHROW(lua.script("assert(test(10, 11, \"hello\") == 11)"));
 
     // function retrieval
-    sol::function test = lua[ "test" ];
+    sol::function test = lua["test"];
     REQUIRE(test.call<int>(10, 11, "hello") == 11);
 
     // setting a lambda
@@ -312,13 +312,13 @@ TEST_CASE("tables/operator[]", "Check if operator[] retrieval and setting works 
     REQUIRE_NOTHROW(lua.script("assert(lamb(220) == 440)"));
 
     // function retrieval of a lambda
-    sol::function lamb = lua[ "lamb" ];
+    sol::function lamb = lua["lamb"];
     REQUIRE(lamb.call<int>(220) == 440);
 
     // test const table retrieval
     auto assert1 = [](const sol::table& t) {
         std::string a = t["foo"];
-	   int b = t["bar"];
+        int b = t["bar"];
         std::cout << a << ',' << b << '\n';
     };
 


### PR DESCRIPTION
Fully supporting `operator[]` by having a stronger proxy type which performs overload resolution ranking among other tricks to make sure users can use `lua["foo"]( bar )` and other neat tricks for natural and consistent access to the lua state.
