### PR TITLE
Add include for std::free from <cstdlib>

### DIFF
--- a/sol/demangle.hpp
+++ b/sol/demangle.hpp
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <array>
+#include <cstdlib>
 
 #if defined(__GNUC__) || defined(__clang__)
 #include <cxxabi.h>
@@ -41,7 +42,7 @@ std::string get_type_name(const std::type_info& id) {
     int status;
     char* unmangled = abi::__cxa_demangle(id.name(), 0, 0, &status);
     std::string realname = unmangled;
-    free(unmangled);
+    std::free(unmangled);
     return realname;
 }
 


### PR DESCRIPTION
I was getting an error about `free` being undefined, so included and used the function from `<cstdlib>`. It seems to be the same as the C function.

```
../deps/sol/sol/demangle.hpp:44:5: error: use of undeclared identifier 'free'
    free(unmangled);
    ^
```

My compiler version: `Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)`
