### PR TITLE
Proper std::ref semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build.ninja
 main.ninja
 *.user
 *.3cb9f6a
+luajit-2.0.3/
+.dropbox*
+desktop.ini

--- a/sol/deprecate.hpp
+++ b/sol/deprecate.hpp
@@ -32,4 +32,13 @@
     #endif // compilers
 #endif // SOL_DEPRECATED
 
+namespace sol {
+namespace detail {
+   template <typename T>
+   struct SOL_DEPRECATED deprecate_type {
+       using type = T;
+   };
+} // detail
+} // sol
+
 #endif // SOL_DEPRECATE_HPP

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -247,7 +247,7 @@ struct base_function {
         return base_gc(L, *pudata);
     }
 
-    template<std::size_t I>
+    template<int I>
     struct userdata {
         static int call(lua_State* L) {
             // Zero-based template parameter, but upvalues start at 1
@@ -259,7 +259,7 @@ struct base_function {
         }
 
         static int gc(lua_State* L) {
-            for(std::size_t i = 0; i < I; ++i) {
+            for(int i = 0; i < I; ++i) {
                 upvalue_t up = stack::get<upvalue_t>(L, i + 1);
                 base_function* obj = static_cast<base_function*>(up.value);
                 std::allocator<base_function> alloc{};

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -259,7 +259,7 @@ struct base_function {
         }
 
         template <std::size_t limit>
-        static void func_gc (std::true_type, lua_State* L) {
+        static void func_gc (std::true_type, lua_State*) {
 
         }
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -92,12 +92,12 @@ template<typename T, typename>
 struct getter {
     template<typename U = T, EnableIf<std::is_floating_point<U>> = 0>
     static U get(lua_State* L, int index = -1) {
-        return lua_tonumber(L, index);
+        return static_cast<U>(lua_tonumber(L, index));
     }
 
     template<typename U = T, EnableIf<std::is_integral<U>, std::is_signed<U>> = 0>
     static U get(lua_State* L, int index = -1) {
-        return lua_tounsigned(L, index);
+        return static_cast<U>(lua_tounsigned(L, index));
     }
 
     template<typename U = T, EnableIf<std::is_integral<U>, std::is_unsigned<U>> = 0>
@@ -162,7 +162,7 @@ struct getter<std::string> {
     static std::string get(lua_State* L, int index = -1) {
         std::string::size_type len;
         auto str = lua_tolstring(L, index, &len);
-        return{ str, len };
+        return { str, len };
     }
 };
 

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -29,7 +29,8 @@
 namespace sol {
 namespace detail {
 inline int atpanic(lua_State* L) {
-    std::string err = lua_tostring(L, -1);
+    const char* message = lua_tostring(L, -1);
+    std::string err = message ? message : "An unexpected error occured and forced the lua state to call atpanic";
     throw error(err);
 }
 } // detail

--- a/sol/tuple.hpp
+++ b/sol/tuple.hpp
@@ -93,6 +93,9 @@ struct constructors {};
 
 const auto default_constructor = constructors<types<>>{};
 
+template <typename T>
+using ref = std::reference_wrapper<T>;
+
 } // sol
 
 #endif // SOL_TUPLE_HPP


### PR DESCRIPTION
This pull request ensures proper `std::ref` semantics and makes `get` and `set` on `table` obey those semantics.

A `sol::ref` type was added to make the `lua.get<sol::ref<T>>` less painful than `lua.get<std::reference_wrapper<T>>` syntax, and `sol::ref<T>` is just a using alias for `std::reference_wrapper`.
