### PR TITLE
fix tautological compare error

### DIFF
--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -247,7 +247,7 @@ struct base_function {
         return base_gc(L, *pudata);
     }
 
-    template<std::size_t I>
+    template<int I>
     struct userdata {
         static int call(lua_State* L) {
             // Zero-based template parameter, but upvalues start at 1
@@ -259,7 +259,7 @@ struct base_function {
         }
 
         static int gc(lua_State* L) {
-            for(std::size_t i = 0; i < I; ++i) {
+            for(int i = 0; i < I; ++i) {
                 upvalue_t up = stack::get<upvalue_t>(L, i + 1);
                 base_function* obj = static_cast<base_function*>(up.value);
                 std::allocator<base_function> alloc{};


### PR DESCRIPTION
In case of userdata I=0, size_t i(0) is never less than 0, causing a tautological-compare warning.

sol/function_types.hpp:262:38: error: comparison of unsigned expression < 0 is always
      false [-Werror,-Wtautological-compare]

FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610
Target: x86_64-unknown-freebsd10.0
Thread model: posix
