### PR TITLE
add test for tautological-compare error

### DIFF
--- a/tests.cpp
+++ b/tests.cpp
@@ -871,3 +871,27 @@ TEST_CASE("regressions/one", "issue number 48") {
     auto* ptr = &my_var;
     REQUIRE(ptr->boop == 1);
 }
+
+namespace
+{
+
+class ClassWithTwoInts
+{
+  public:
+    ClassWithTwoInts( int a, int b )
+      : a( a )
+      , b( b )
+    {
+    }
+
+    const int a;
+    const int b;
+};
+
+}
+
+TEST_CASE("user data creation", "class with two int parameters") {
+    sol::state lua;
+    lua.new_userdata< ClassWithTwoInts, int, int >("class_with_two_ints" );
+}
+


### PR DESCRIPTION
I'm not sure if you would like to add a test for it, but I've managed to reproduce the previous issue. Also I don't know your test suit / case naming conventions, so don't hesitate to throw this one out if you think.
