### PR TITLE
LuaJIT and Lua 5.1 compatibility layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ luajit-2.0.3/
 .dropbox*
 desktop.ini
 lua-5.3.0/
+.vs/
+lua-5.1.5/
+luajit-2.0.4/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ lua-5.3.0/
 .vs/
 lua-5.1.5/
 luajit-2.0.4/
+*.creator.user.*

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ lua-5.3.0/
 lua-5.1.5/
 luajit-2.0.4/
 *.creator.user.*
+lua-5.3.1/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lua-5.1.5/
 luajit-2.0.4/
 *.creator.user.*
 lua-5.3.1/
+main2.cpp

--- a/examples/userdata.cpp
+++ b/examples/userdata.cpp
@@ -43,15 +43,15 @@ int main() {
     lua.open_libraries(sol::lib::base, sol::lib::math);
 
     // the simplest way to create a class is through
-    // sol::state::new_userdata
+    // sol::state::new_usertype
     // the first template is the class type
     // the rest are the constructor parameters
-    // using new_userdata you can only have one constructor
+    // using new_usertype you can only have one constructor
 
 
     // you must make sure that the name of the function
     // goes before the member function pointer
-    lua.new_userdata<foo, std::string>("foo", "print", &foo::print, "test", &foo::test);
+    lua.new_usertype<foo, std::string>("foo", "print", &foo::print, "test", &foo::test);
 
     // making the class from lua is simple
     // same with calling member functions
@@ -63,8 +63,8 @@ int main() {
     assert(y == 14);
 
     // if you want a class to have more than one constructor
-    // the way to do so is through set_userdata and creating
-    // a userdata yourself with constructor types
+    // the way to do so is through set_usertype and creating
+    // a usertype yourself with constructor types
 
     {
         // Notice the brace: this means we're in a new scope
@@ -75,15 +75,15 @@ int main() {
         // the first argument of construction is the name
         // second is the constructor types
         // then the rest are function name and member function pointer pairs
-        sol::userdata<vector> udata("vector", ctor, "is_unit", &vector::is_unit);
+        sol::usertype<vector> udata(ctor, "is_unit", &vector::is_unit);
 
         // then you must register it
-        lua.set_userdata(udata);
-        // You can throw away the userdata after you set it: you do NOT
+        lua.set_usertype("vector", udata);
+        // You can throw away the usertype after you set it: you do NOT
         // have to keep it around
         // cleanup happens automagically
     }
-    // calling it is the same as new_userdata
+    // calling it is the same as new_usertype
 
     lua.script("v = vector.new()\n"
                "v = vector.new(12)\n"
@@ -92,7 +92,7 @@ int main() {
 
     // You can even have C++-like member-variable-access
     // just pass is public member variables in the same style as functions
-    lua.new_userdata<variables>("variables", "low_gravity", &variables::low_gravity, "boost_level", &variables::boost_level);
+    lua.new_usertype<variables>("variables", "low_gravity", &variables::low_gravity, "boost_level", &variables::boost_level);
 
     // making the class from lua is simple
     // same with calling member functions/variables

--- a/sol/compatibility.hpp
+++ b/sol/compatibility.hpp
@@ -19,11 +19,23 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOL_HPP
-#define SOL_HPP
+#ifndef SOL_COMPATIBILITY_HPP
+#define SOL_COMPATIBILITY_HPP
 
-#include "sol/state.hpp"
-#include "sol/object.hpp"
-#include "sol/function.hpp"
+// The various pieces of the compatibility layer
+// comes from https://github.com/keplerproject/lua-compat-5.2
+// but has been modified in many places for use with Sol and luajit,
+// though the core abstractions remain the same
+#include "compatibility/version.hpp"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "compatibility/5.1.0.h"
+#include "compatibility/5.0.0.h"
+#include "compatibility/5.x.x.h"
+#include "compatibility/5.x.x.inl"
+#ifdef __cplusplus
+}
+#endif
 
-#endif // SOL_HPP
+#endif // SOL_COMPATIBILITY_HPP

--- a/sol/compatibility/5.0.0.h
+++ b/sol/compatibility/5.0.0.h
@@ -19,11 +19,26 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOL_HPP
-#define SOL_HPP
+#ifndef SOL_5_0_0_H
+#define SOL_5_0_0_H
 
-#include "sol/state.hpp"
-#include "sol/object.hpp"
-#include "sol/function.hpp"
+#include "version.hpp"
 
-#endif // SOL_HPP
+#if SOL_LUA_VERSION < 501
+/* Lua 5.0 */
+
+#define LUA_QL(x) "'" x "'"
+#define LUA_QS LUA_QL("%s")
+
+#define luaL_Reg luaL_reg
+
+#define luaL_opt(L, f, n, d) \
+  (lua_isnoneornil(L, n) ? (d) : f(L, n))
+
+#define luaL_addchar(B,c) \
+  ((void)((B)->p < ((B)->buffer+LUAL_BUFFERSIZE) || luaL_prepbuffer(B)), \
+   (*(B)->p++ = (char)(c)))
+
+#endif // Lua 5.0
+
+#endif // SOL_5_0_0_H

--- a/sol/compatibility/5.1.0.h
+++ b/sol/compatibility/5.1.0.h
@@ -60,14 +60,13 @@
 typedef LUAI_UINT32 lua_Unsigned;
 
 typedef struct luaL_Buffer_52 {
-	luaL_Buffer b; /* make incorrect code crash! */
-	char *ptr;
-	size_t nelems;
-	size_t capacity;
-	lua_State *L2;
+    luaL_Buffer b; /* make incorrect code crash! */
+    char *ptr;
+    size_t nelems;
+    size_t capacity;
+    lua_State *L2;
 } luaL_Buffer_52;
 #define luaL_Buffer luaL_Buffer_52
-
 
 #define lua_tounsigned(L, i) lua_tounsignedx(L, i, NULL)
 

--- a/sol/compatibility/5.1.0.h
+++ b/sol/compatibility/5.1.0.h
@@ -1,0 +1,130 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2015 Danny Y., Rapptz
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SOL_5_1_0_H
+#define SOL_5_1_0_H
+
+#include "version.hpp"
+
+#if SOL_LUA_VERSION == 501
+/* Lua 5.1 */
+
+#include <lua.hpp>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+/* LuaJIT doesn't define these unofficial macros ... */
+#if !defined(LUAI_INT32)
+#include <limits.h>
+#if INT_MAX-20 < 32760
+#define LUAI_INT32  long
+#define LUAI_UINT32 unsigned long
+#elif INT_MAX > 2147483640L
+#define LUAI_INT32  int
+#define LUAI_UINT32 unsigned int
+#else
+#error "could not detect suitable lua_Unsigned datatype"
+#endif
+#endif
+
+#define LUA_OPADD 0
+#define LUA_OPSUB 1
+#define LUA_OPMUL 2
+#define LUA_OPDIV 3
+#define LUA_OPMOD 4
+#define LUA_OPPOW 5
+#define LUA_OPUNM 6
+#define LUA_OPEQ 0
+#define LUA_OPLT 1
+#define LUA_OPLE 2
+
+typedef LUAI_UINT32 lua_Unsigned;
+
+typedef struct luaL_Buffer_52 {
+	luaL_Buffer b; /* make incorrect code crash! */
+	char *ptr;
+	size_t nelems;
+	size_t capacity;
+	lua_State *L2;
+} luaL_Buffer_52;
+#define luaL_Buffer luaL_Buffer_52
+
+
+#define lua_tounsigned(L, i) lua_tounsignedx(L, i, NULL)
+
+#define lua_rawlen(L, i) lua_objlen(L, i)
+
+void lua_arith(lua_State *L, int op);
+int lua_compare(lua_State *L, int idx1, int idx2, int op);
+void lua_pushunsigned(lua_State *L, lua_Unsigned n);
+lua_Unsigned luaL_checkunsigned(lua_State *L, int i);
+lua_Unsigned lua_tounsignedx(lua_State *L, int i, int *isnum);
+lua_Unsigned luaL_optunsigned(lua_State *L, int i, lua_Unsigned def);
+lua_Integer lua_tointegerx(lua_State *L, int i, int *isnum);
+void lua_len(lua_State *L, int i);
+int luaL_len(lua_State *L, int i);
+const char *luaL_tolstring(lua_State *L, int idx, size_t *len);
+void luaL_requiref(lua_State *L, char const* modname, lua_CFunction openf, int glb);
+
+#define luaL_buffinit luaL_buffinit_52
+void luaL_buffinit(lua_State *L, luaL_Buffer_52 *B);
+
+#define luaL_prepbuffsize luaL_prepbuffsize_52
+char *luaL_prepbuffsize(luaL_Buffer_52 *B, size_t s);
+
+#define luaL_addlstring luaL_addlstring_52
+void luaL_addlstring(luaL_Buffer_52 *B, const char *s, size_t l);
+
+#define luaL_addvalue luaL_addvalue_52
+void luaL_addvalue(luaL_Buffer_52 *B);
+
+#define luaL_pushresult luaL_pushresult_52
+void luaL_pushresult(luaL_Buffer_52 *B);
+
+#undef luaL_buffinitsize
+#define luaL_buffinitsize(L, B, s) \
+  (luaL_buffinit(L, B), luaL_prepbuffsize(B, s))
+
+#undef luaL_prepbuffer
+#define luaL_prepbuffer(B) \
+  luaL_prepbuffsize(B, LUAL_BUFFERSIZE)
+
+#undef luaL_addchar
+#define luaL_addchar(B, c) \
+  ((void)((B)->nelems < (B)->capacity || luaL_prepbuffsize(B, 1)), \
+   ((B)->ptr[(B)->nelems++] = (c)))
+
+#undef luaL_addsize
+#define luaL_addsize(B, s) \
+  ((B)->nelems += (s))
+
+#undef luaL_addstring
+#define luaL_addstring(B, s) \
+  luaL_addlstring(B, s, strlen(s))
+
+#undef luaL_pushresultsize
+#define luaL_pushresultsize(B, s) \
+  (luaL_addsize(B, s), luaL_pushresult(B))
+
+#endif /* Lua 5.1 */
+
+#endif // SOL_5_1_0_H

--- a/sol/compatibility/5.x.x.h
+++ b/sol/compatibility/5.x.x.h
@@ -24,7 +24,7 @@
 
 #include "version.hpp"
 
-#if SOL_LUA_VERSION < 520
+#if SOL_LUA_VERSION < 502
 
 #define LUA_RIDX_GLOBALS LUA_GLOBALSINDEX
 

--- a/sol/compatibility/5.x.x.h
+++ b/sol/compatibility/5.x.x.h
@@ -19,11 +19,39 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOL_HPP
-#define SOL_HPP
+#ifndef SOL_5_X_X_H
+#define SOL_5_X_X_H
 
-#include "sol/state.hpp"
-#include "sol/object.hpp"
-#include "sol/function.hpp"
+#include "version.hpp"
 
-#endif // SOL_HPP
+#if SOL_LUA_VERSION < 520
+
+#define LUA_RIDX_GLOBALS LUA_GLOBALSINDEX
+
+#define LUA_OK 0
+
+#define lua_pushglobaltable(L) \
+  lua_pushvalue(L, LUA_GLOBALSINDEX)
+
+#define luaL_newlib(L, l) \
+  (lua_newtable((L)),luaL_setfuncs((L), (l), 0))
+
+void luaL_checkversion(lua_State *L);
+
+int lua_absindex(lua_State *L, int i);
+void lua_copy(lua_State *L, int from, int to);
+void lua_rawgetp(lua_State *L, int i, const void *p);
+void lua_rawsetp(lua_State *L, int i, const void *p);
+void *luaL_testudata(lua_State *L, int i, const char *tname);
+lua_Number lua_tonumberx(lua_State *L, int i, int *isnum);
+void lua_getuservalue(lua_State *L, int i);
+void lua_setuservalue(lua_State *L, int i);
+void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup);
+void luaL_setmetatable(lua_State *L, const char *tname);
+int luaL_getsubtable(lua_State *L, int i, const char *name);
+void luaL_traceback(lua_State *L, lua_State *L1, const char *msg, int level);
+int luaL_fileresult(lua_State *L, int stat, const char *fname);
+
+#endif // Lua 5.1 and below
+
+#endif // SOL_5_X_X_H

--- a/sol/compatibility/5.x.x.inl
+++ b/sol/compatibility/5.x.x.inl
@@ -1,0 +1,678 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2015 Danny Y., Rapptz
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SOL_5_X_X_INL
+#define SOL_5_X_X_INL
+
+#include "version.hpp"
+#include "5.1.0.h"
+#include "5.0.0.h"
+#include "5.x.x.h"
+
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM == 501
+
+#include <errno.h>
+#include <string.h>
+
+#define PACKAGE_KEY "_sol.package"
+
+inline int lua_absindex(lua_State *L, int i) {
+	if (i < 0 && i > LUA_REGISTRYINDEX)
+		i += lua_gettop(L) + 1;
+	return i;
+}
+
+inline void lua_copy(lua_State *L, int from, int to) {
+	int abs_to = lua_absindex(L, to);
+	luaL_checkstack(L, 1, "not enough stack slots");
+	lua_pushvalue(L, from);
+	lua_replace(L, abs_to);
+}
+
+inline void lua_rawgetp(lua_State *L, int i, const void *p) {
+	int abs_i = lua_absindex(L, i);
+	lua_pushlightuserdata(L, (void*)p);
+	lua_rawget(L, abs_i);
+}
+
+inline void lua_rawsetp(lua_State *L, int i, const void *p) {
+	int abs_i = lua_absindex(L, i);
+	luaL_checkstack(L, 1, "not enough stack slots");
+	lua_pushlightuserdata(L, (void*)p);
+	lua_insert(L, -2);
+	lua_rawset(L, abs_i);
+}
+
+inline void *luaL_testudata(lua_State *L, int i, const char *tname) {
+	void *p = lua_touserdata(L, i);
+	luaL_checkstack(L, 2, "not enough stack slots");
+	if (p == NULL || !lua_getmetatable(L, i))
+		return NULL;
+	else {
+		int res = 0;
+		luaL_getmetatable(L, tname);
+		res = lua_rawequal(L, -1, -2);
+		lua_pop(L, 2);
+		if (!res)
+			p = NULL;
+	}
+	return p;
+}
+
+inline lua_Number lua_tonumberx(lua_State *L, int i, int *isnum) {
+	lua_Number n = lua_tonumber(L, i);
+	if (isnum != NULL) {
+		*isnum = (n != 0 || lua_isnumber(L, i));
+	}
+	return n;
+}
+
+inline static void push_package_table(lua_State *L) {
+	lua_pushliteral(L, PACKAGE_KEY);
+	lua_rawget(L, LUA_REGISTRYINDEX);
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
+		/* try to get package table from globals */
+		lua_pushliteral(L, "package");
+		lua_rawget(L, LUA_GLOBALSINDEX);
+		if (lua_istable(L, -1)) {
+			lua_pushliteral(L, PACKAGE_KEY);
+			lua_pushvalue(L, -2);
+			lua_rawset(L, LUA_REGISTRYINDEX);
+		}
+	}
+}
+
+inline void lua_getuservalue(lua_State *L, int i) {
+	luaL_checktype(L, i, LUA_TUSERDATA);
+	luaL_checkstack(L, 2, "not enough stack slots");
+	lua_getfenv(L, i);
+	lua_pushvalue(L, LUA_GLOBALSINDEX);
+	if (lua_rawequal(L, -1, -2)) {
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		lua_replace(L, -2);
+	}
+	else {
+		lua_pop(L, 1);
+		push_package_table(L);
+		if (lua_rawequal(L, -1, -2)) {
+			lua_pop(L, 1);
+			lua_pushnil(L);
+			lua_replace(L, -2);
+		}
+		else
+			lua_pop(L, 1);
+	}
+}
+
+inline void lua_setuservalue(lua_State *L, int i) {
+	luaL_checktype(L, i, LUA_TUSERDATA);
+	if (lua_isnil(L, -1)) {
+		luaL_checkstack(L, 1, "not enough stack slots");
+		lua_pushvalue(L, LUA_GLOBALSINDEX);
+		lua_replace(L, -2);
+	}
+	lua_setfenv(L, i);
+}
+
+/*
+** Adapted from Lua 5.2.0
+*/
+inline void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
+	luaL_checkstack(L, nup + 1, "too many upvalues");
+	for (; l->name != NULL; l++) {  /* fill the table with given functions */
+		int i;
+		lua_pushstring(L, l->name);
+		for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+			lua_pushvalue(L, -(nup + 1));
+		lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+		lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
+	}
+	lua_pop(L, nup);  /* remove upvalues */
+}
+
+inline void luaL_setmetatable(lua_State *L, const char *tname) {
+	luaL_checkstack(L, 1, "not enough stack slots");
+	luaL_getmetatable(L, tname);
+	lua_setmetatable(L, -2);
+}
+
+inline int luaL_getsubtable(lua_State *L, int i, const char *name) {
+	int abs_i = lua_absindex(L, i);
+	luaL_checkstack(L, 3, "not enough stack slots");
+	lua_pushstring(L, name);
+	lua_gettable(L, abs_i);
+	if (lua_istable(L, -1))
+		return 1;
+	lua_pop(L, 1);
+	lua_newtable(L);
+	lua_pushstring(L, name);
+	lua_pushvalue(L, -2);
+	lua_settable(L, abs_i);
+	return 0;
+}
+
+#ifndef SOL_LUAJIT
+inline static int countlevels(lua_State *L) {
+	lua_Debug ar;
+	int li = 1, le = 1;
+	/* find an upper bound */
+	while (lua_getstack(L, le, &ar)) { li = le; le *= 2; }
+	/* do a binary search */
+	while (li < le) {
+		int m = (li + le) / 2;
+		if (lua_getstack(L, m, &ar)) li = m + 1;
+		else le = m;
+	}
+	return le - 1;
+}
+
+inline static int findfield(lua_State *L, int objidx, int level) {
+	if (level == 0 || !lua_istable(L, -1))
+		return 0;  /* not found */
+	lua_pushnil(L);  /* start 'next' loop */
+	while (lua_next(L, -2)) {  /* for each pair in table */
+		if (lua_type(L, -2) == LUA_TSTRING) {  /* ignore non-string keys */
+			if (lua_rawequal(L, objidx, -1)) {  /* found object? */
+				lua_pop(L, 1);  /* remove value (but keep name) */
+				return 1;
+			}
+			else if (findfield(L, objidx, level - 1)) {  /* try recursively */
+				lua_remove(L, -2);  /* remove table (but keep name) */
+				lua_pushliteral(L, ".");
+				lua_insert(L, -2);  /* place '.' between the two names */
+				lua_concat(L, 3);
+				return 1;
+			}
+		}
+		lua_pop(L, 1);  /* remove value */
+	}
+	return 0;  /* not found */
+}
+
+inline static int pushglobalfuncname(lua_State *L, lua_Debug *ar) {
+	int top = lua_gettop(L);
+	lua_getinfo(L, "f", ar);  /* push function */
+	lua_pushvalue(L, LUA_GLOBALSINDEX);
+	if (findfield(L, top + 1, 2)) {
+		lua_copy(L, -1, top + 1);  /* move name to proper place */
+		lua_pop(L, 2);  /* remove pushed values */
+		return 1;
+	}
+	else {
+		lua_settop(L, top);  /* remove function and global table */
+		return 0;
+	}
+}
+
+inline static void pushfuncname(lua_State *L, lua_Debug *ar) {
+	if (*ar->namewhat != '\0')  /* is there a name? */
+		lua_pushfstring(L, "function " LUA_QS, ar->name);
+	else if (*ar->what == 'm')  /* main? */
+		lua_pushliteral(L, "main chunk");
+	else if (*ar->what == 'C') {
+		if (pushglobalfuncname(L, ar)) {
+			lua_pushfstring(L, "function " LUA_QS, lua_tostring(L, -1));
+			lua_remove(L, -2);  /* remove name */
+		}
+		else
+			lua_pushliteral(L, "?");
+	}
+	else
+		lua_pushfstring(L, "function <%s:%d>", ar->short_src, ar->linedefined);
+}
+
+#define LEVELS1 12  /* size of the first part of the stack */
+#define LEVELS2 10  /* size of the second part of the stack */
+
+inline void luaL_traceback(lua_State *L, lua_State *L1,
+	const char *msg, int level) {
+	lua_Debug ar;
+	int top = lua_gettop(L);
+	int numlevels = countlevels(L1);
+	int mark = (numlevels > LEVELS1 + LEVELS2) ? LEVELS1 : 0;
+	if (msg) lua_pushfstring(L, "%s\n", msg);
+	lua_pushliteral(L, "stack traceback:");
+	while (lua_getstack(L1, level++, &ar)) {
+		if (level == mark) {  /* too many levels? */
+			lua_pushliteral(L, "\n\t...");  /* add a '...' */
+			level = numlevels - LEVELS2;  /* and skip to last ones */
+		}
+		else {
+			lua_getinfo(L1, "Slnt", &ar);
+			lua_pushfstring(L, "\n\t%s:", ar.short_src);
+			if (ar.currentline > 0)
+				lua_pushfstring(L, "%d:", ar.currentline);
+			lua_pushliteral(L, " in ");
+			pushfuncname(L, &ar);
+			lua_concat(L, lua_gettop(L) - top);
+		}
+	}
+	lua_concat(L, lua_gettop(L) - top);
+}
+#endif
+
+
+inline void luaL_checkversion(lua_State *L) {
+	(void)L;
+}
+
+#ifndef SOL_LUAJIT
+inline int luaL_fileresult(lua_State *L, int stat, const char *fname) {
+	int en = errno;  /* calls to Lua API may change this value */
+	if (stat) {
+		lua_pushboolean(L, 1);
+		return 1;
+	}
+	else {
+		lua_pushnil(L);
+		if (fname)
+			lua_pushfstring(L, "%s: %s", fname, strerror(en));
+		else
+			lua_pushstring(L, strerror(en));
+		lua_pushnumber(L, (lua_Number)en);
+		return 3;
+	}
+}
+#endif // luajit
+#endif // Lua 5.0 or Lua 5.1
+
+
+#if SOL_LUA_VERSION == 501
+#include <limits.h>
+
+typedef LUAI_INT32 LUA_INT32;
+
+/********************************************************************/
+/*                    extract of 5.2's luaconf.h                    */
+/*  detects proper defines for faster unsigned<->number conversion  */
+/*           see copyright notice at the end of this file           */
+/********************************************************************/
+
+#if !defined(LUA_ANSI) && defined(_WIN32) && !defined(_WIN32_WCE)
+#define LUA_WIN		/* enable goodies for regular Windows platforms */
+#endif
+
+
+#if defined(LUA_NUMBER_DOUBLE) && !defined(LUA_ANSI)	/* { */
+
+/* Microsoft compiler on a Pentium (32 bit) ? */
+#if defined(LUA_WIN) && defined(_MSC_VER) && defined(_M_IX86)	/* { */
+
+#define LUA_MSASMTRICK
+#define LUA_IEEEENDIAN		0
+#define LUA_NANTRICK
+
+/* pentium 32 bits? */
+#elif defined(__i386__) || defined(__i386) || defined(__X86__) /* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEELL
+#define LUA_IEEEENDIAN		0
+#define LUA_NANTRICK
+
+/* pentium 64 bits? */
+#elif defined(__x86_64)						/* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEEENDIAN		0
+
+#elif defined(__POWERPC__) || defined(__ppc__)			/* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEEENDIAN		1
+
+#else								/* }{ */
+
+/* assume IEEE754 and a 32-bit integer type */
+#define LUA_IEEE754TRICK
+
+#endif								/* } */
+
+#endif							/* } */
+
+
+/********************************************************************/
+/*                    extract of 5.2's llimits.h                    */
+/*       gives us lua_number2unsigned and lua_unsigned2number       */
+/*           see copyright notice just below this one here          */
+/********************************************************************/
+
+/*********************************************************************
+* This file contains parts of Lua 5.2's source code:
+*
+* Copyright (C) 1994-2013 Lua.org, PUC-Rio.
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*********************************************************************/
+
+#if defined(MS_ASMTRICK) || defined(LUA_MSASMTRICK)	/* { */
+/* trick with Microsoft assembler for X86 */
+
+#define lua_number2unsigned(i,n)  \
+  {__int64 l; __asm {__asm fld n   __asm fistp l} i = (unsigned int)l;}
+
+
+#elif defined(LUA_IEEE754TRICK)		/* }{ */
+/* the next trick should work on any machine using IEEE754 with
+a 32-bit int type */
+
+union compat52_luai_Cast { double l_d; LUA_INT32 l_p[2]; };
+
+#if !defined(LUA_IEEEENDIAN)	/* { */
+#define LUAI_EXTRAIEEE	\
+  static const union compat52_luai_Cast ieeeendian = {-(33.0 + 6755399441055744.0)};
+#define LUA_IEEEENDIANLOC	(ieeeendian.l_p[1] == 33)
+#else
+#define LUA_IEEEENDIANLOC	LUA_IEEEENDIAN
+#define LUAI_EXTRAIEEE		/* empty */
+#endif				/* } */
+
+#define lua_number2int32(i,n,t) \
+  { LUAI_EXTRAIEEE \
+    volatile union compat52_luai_Cast u; u.l_d = (n) + 6755399441055744.0; \
+    (i) = (t)u.l_p[LUA_IEEEENDIANLOC]; }
+
+#define lua_number2unsigned(i,n)	lua_number2int32(i, n, lua_Unsigned)
+
+#endif				/* } */
+
+
+/* the following definitions always work, but may be slow */
+
+#if !defined(lua_number2unsigned)	/* { */
+/* the following definition assures proper modulo behavior */
+#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_NUMBER_FLOAT)
+#include <math.h>
+#define SUPUNSIGNED	((lua_Number)(~(lua_Unsigned)0) + 1)
+#define lua_number2unsigned(i,n)  \
+	((i)=(lua_Unsigned)((n) - floor((n)/SUPUNSIGNED)*SUPUNSIGNED))
+#else
+#define lua_number2unsigned(i,n)	((i)=(lua_Unsigned)(n))
+#endif
+#endif				/* } */
+
+
+#if !defined(lua_unsigned2number)
+/* on several machines, coercion from unsigned to double is slow,
+so it may be worth to avoid */
+#define lua_unsigned2number(u)  \
+    (((u) <= (lua_Unsigned)INT_MAX) ? (lua_Number)(int)(u) : (lua_Number)(u))
+#endif
+
+/********************************************************************/
+
+inline static void compat52_call_lua(lua_State *L, char const code[], size_t len,
+	int nargs, int nret) {
+	lua_rawgetp(L, LUA_REGISTRYINDEX, (void*)code);
+	if (lua_type(L, -1) != LUA_TFUNCTION) {
+		lua_pop(L, 1);
+		if (luaL_loadbuffer(L, code, len, "=none"))
+			lua_error(L);
+		lua_pushvalue(L, -1);
+		lua_rawsetp(L, LUA_REGISTRYINDEX, (void*)code);
+	}
+	lua_insert(L, -nargs - 1);
+	lua_call(L, nargs, nret);
+}
+
+static const char compat52_arith_code[] = {
+	"local op,a,b=...\n"
+	"if op==0 then return a+b\n"
+	"elseif op==1 then return a-b\n"
+	"elseif op==2 then return a*b\n"
+	"elseif op==3 then return a/b\n"
+	"elseif op==4 then return a%b\n"
+	"elseif op==5 then return a^b\n"
+	"elseif op==6 then return -a\n"
+	"end\n"
+};
+
+inline void lua_arith(lua_State *L, int op) {
+	if (op < LUA_OPADD || op > LUA_OPUNM)
+		luaL_error(L, "invalid 'op' argument for lua_arith");
+	luaL_checkstack(L, 5, "not enough stack slots");
+	if (op == LUA_OPUNM)
+		lua_pushvalue(L, -1);
+	lua_pushnumber(L, op);
+	lua_insert(L, -3);
+	compat52_call_lua(L, compat52_arith_code,
+		sizeof(compat52_arith_code) - 1, 3, 1);
+}
+
+static const char compat52_compare_code[] = {
+	"local a,b=...\n"
+	"return a<=b\n"
+};
+
+inline int lua_compare(lua_State *L, int idx1, int idx2, int op) {
+	int result = 0;
+	switch (op) {
+	case LUA_OPEQ:
+		return lua_equal(L, idx1, idx2);
+	case LUA_OPLT:
+		return lua_lessthan(L, idx1, idx2);
+	case LUA_OPLE:
+		luaL_checkstack(L, 5, "not enough stack slots");
+		idx1 = lua_absindex(L, idx1);
+		idx2 = lua_absindex(L, idx2);
+		lua_pushvalue(L, idx1);
+		lua_pushvalue(L, idx2);
+		compat52_call_lua(L, compat52_compare_code,
+			sizeof(compat52_compare_code) - 1, 2, 1);
+		result = lua_toboolean(L, -1);
+		lua_pop(L, 1);
+		return result;
+	default:
+		luaL_error(L, "invalid 'op' argument for lua_compare");
+	}
+	return 0;
+}
+
+inline void lua_pushunsigned(lua_State *L, lua_Unsigned n) {
+	lua_pushnumber(L, lua_unsigned2number(n));
+}
+
+inline lua_Unsigned luaL_checkunsigned(lua_State *L, int i) {
+	lua_Unsigned result;
+	lua_Number n = lua_tonumber(L, i);
+	if (n == 0 && !lua_isnumber(L, i))
+		luaL_checktype(L, i, LUA_TNUMBER);
+	lua_number2unsigned(result, n);
+	return result;
+}
+
+inline lua_Unsigned lua_tounsignedx(lua_State *L, int i, int *isnum) {
+	lua_Unsigned result;
+	lua_Number n = lua_tonumberx(L, i, isnum);
+	lua_number2unsigned(result, n);
+	return result;
+}
+
+inline lua_Unsigned luaL_optunsigned(lua_State *L, int i, lua_Unsigned def) {
+	return luaL_opt(L, luaL_checkunsigned, i, def);
+}
+
+inline lua_Integer lua_tointegerx(lua_State *L, int i, int *isnum) {
+	lua_Integer n = lua_tointeger(L, i);
+	if (isnum != NULL) {
+		*isnum = (n != 0 || lua_isnumber(L, i));
+	}
+	return n;
+}
+
+inline void lua_len(lua_State *L, int i) {
+	switch (lua_type(L, i)) {
+	case LUA_TSTRING: /* fall through */
+	case LUA_TTABLE:
+		if (!luaL_callmeta(L, i, "__len"))
+			lua_pushnumber(L, (int)lua_objlen(L, i));
+		break;
+	case LUA_TUSERDATA:
+		if (luaL_callmeta(L, i, "__len"))
+			break;
+		/* maybe fall through */
+	default:
+		luaL_error(L, "attempt to get length of a %s value",
+			lua_typename(L, lua_type(L, i)));
+	}
+}
+
+inline int luaL_len(lua_State *L, int i) {
+	int res = 0, isnum = 0;
+	luaL_checkstack(L, 1, "not enough stack slots");
+	lua_len(L, i);
+	res = (int)lua_tointegerx(L, -1, &isnum);
+	lua_pop(L, 1);
+	if (!isnum)
+		luaL_error(L, "object length is not a number");
+	return res;
+}
+
+inline const char *luaL_tolstring(lua_State *L, int idx, size_t *len) {
+	if (!luaL_callmeta(L, idx, "__tostring")) {
+		int t = lua_type(L, idx);
+		switch (t) {
+		case LUA_TNIL:
+			lua_pushliteral(L, "nil");
+			break;
+		case LUA_TSTRING:
+		case LUA_TNUMBER:
+			lua_pushvalue(L, idx);
+			break;
+		case LUA_TBOOLEAN:
+			if (lua_toboolean(L, idx))
+				lua_pushliteral(L, "true");
+			else
+				lua_pushliteral(L, "false");
+			break;
+		default:
+			lua_pushfstring(L, "%s: %p", lua_typename(L, t),
+				lua_topointer(L, idx));
+			break;
+		}
+	}
+	return lua_tolstring(L, -1, len);
+}
+
+inline void luaL_requiref(lua_State *L, char const* modname,
+	lua_CFunction openf, int glb) {
+	luaL_checkstack(L, 3, "not enough stack slots");
+	lua_pushcfunction(L, openf);
+	lua_pushstring(L, modname);
+	lua_call(L, 1, 1);
+	lua_getglobal(L, "package");
+	if (lua_istable(L, -1) == 0) {
+		lua_pop(L, 1);
+		lua_createtable(L, 0, 16);
+		lua_setglobal(L, "package");
+		lua_getglobal(L, "package");
+	}
+	lua_getfield(L, -1, "loaded");
+	if (lua_istable(L, -1) == 0) {
+		lua_pop(L, 1);
+		lua_createtable(L, 0, 1);
+		lua_setfield(L, -2, "loaded");
+		lua_getfield(L, -1, "loaded");
+	}
+	lua_replace(L, -2);
+	lua_pushvalue(L, -2);
+	lua_setfield(L, -2, modname);
+	lua_pop(L, 1);
+	if (glb) {
+		lua_pushvalue(L, -1);
+		lua_setglobal(L, modname);
+	}
+}
+
+inline void luaL_buffinit(lua_State *L, luaL_Buffer_52 *B) {
+	/* make it crash if used via pointer to a 5.1-style luaL_Buffer */
+	B->b.p = NULL;
+	B->b.L = NULL;
+	B->b.lvl = 0;
+	/* reuse the buffer from the 5.1-style luaL_Buffer though! */
+	B->ptr = B->b.buffer;
+	B->capacity = LUAL_BUFFERSIZE;
+	B->nelems = 0;
+	B->L2 = L;
+}
+
+inline char *luaL_prepbuffsize(luaL_Buffer_52 *B, size_t s) {
+	if (B->capacity - B->nelems < s) { /* needs to grow */
+		char* newptr = NULL;
+		size_t newcap = B->capacity * 2;
+		if (newcap - B->nelems < s)
+			newcap = B->nelems + s;
+		if (newcap < B->capacity) /* overflow */
+			luaL_error(B->L2, "buffer too large");
+		newptr = (char*)lua_newuserdata(B->L2, newcap);
+		memcpy(newptr, B->ptr, B->nelems);
+		if (B->ptr != B->b.buffer)
+			lua_replace(B->L2, -2); /* remove old buffer */
+		B->ptr = newptr;
+		B->capacity = newcap;
+	}
+	return B->ptr + B->nelems;
+}
+
+inline void luaL_addlstring(luaL_Buffer_52 *B, const char *s, size_t l) {
+	memcpy(luaL_prepbuffsize(B, l), s, l);
+	luaL_addsize(B, l);
+}
+
+inline void luaL_addvalue(luaL_Buffer_52 *B) {
+	size_t len = 0;
+	const char *s = lua_tolstring(B->L2, -1, &len);
+	if (!s)
+		luaL_error(B->L2, "cannot convert value to string");
+	if (B->ptr != B->b.buffer)
+		lua_insert(B->L2, -2); /* userdata buffer must be at stack top */
+	luaL_addlstring(B, s, len);
+	lua_remove(B->L2, B->ptr != B->b.buffer ? -2 : -1);
+}
+
+inline void luaL_pushresult(luaL_Buffer_52 *B) {
+	lua_pushlstring(B->L2, B->ptr, B->nelems);
+	if (B->ptr != B->b.buffer)
+		lua_replace(B->L2, -2); /* remove userdata buffer */
+}
+
+#endif /* SOL_LUA_VERSION == 501 */
+
+#endif // SOL_5_X_X_INL

--- a/sol/compatibility/5.x.x.inl
+++ b/sol/compatibility/5.x.x.inl
@@ -272,31 +272,31 @@ inline void luaL_traceback(lua_State *L, lua_State *L1,
 #endif
 
 inline const lua_Number *lua_version(lua_State *L) {
-	static const lua_Number version = LUA_VERSION_NUM;
-	if (L == NULL) return &version;
-	// TODO: wonky hacks to get at the inside of the incomplete type lua_State?
-	//else return L->l_G->version;
-	else return &version;
+    static const lua_Number version = LUA_VERSION_NUM;
+    if (L == NULL) return &version;
+    // TODO: wonky hacks to get at the inside of the incomplete type lua_State?
+    //else return L->l_G->version;
+    else return &version;
 }
 
 inline static void luaL_checkversion_(lua_State *L, lua_Number ver) {
-	const lua_Number* v = lua_version(L);
-	if (v != lua_version(NULL))
-		luaL_error(L, "multiple Lua VMs detected");
-	else if (*v != ver)
-		luaL_error(L, "version mismatch: app. needs %f, Lua core provides %f",
-			ver, *v);
-	/* check conversions number -> integer types */
-	lua_pushnumber(L, -(lua_Number)0x1234);
-	if (lua_tointeger(L, -1) != -0x1234 ||
-		lua_tounsigned(L, -1) != (lua_Unsigned)-0x1234)
-		luaL_error(L, "bad conversion number->int;"
-			" must recompile Lua with proper settings");
-	lua_pop(L, 1);
+    const lua_Number* v = lua_version(L);
+    if (v != lua_version(NULL))
+        luaL_error(L, "multiple Lua VMs detected");
+    else if (*v != ver)
+        luaL_error(L, "version mismatch: app. needs %f, Lua core provides %f",
+            ver, *v);
+    /* check conversions number -> integer types */
+    lua_pushnumber(L, -(lua_Number)0x1234);
+    if (lua_tointeger(L, -1) != -0x1234 ||
+        lua_tounsigned(L, -1) != (lua_Unsigned)-0x1234)
+        luaL_error(L, "bad conversion number->int;"
+            " must recompile Lua with proper settings");
+    lua_pop(L, 1);
 }
 
 inline void luaL_checkversion(lua_State* L) {
-	luaL_checkversion_(L, LUA_VERSION_NUM);
+    luaL_checkversion_(L, LUA_VERSION_NUM);
 }
 
 #ifndef SOL_LUAJIT

--- a/sol/compatibility/5.x.x.inl
+++ b/sol/compatibility/5.x.x.inl
@@ -35,263 +35,263 @@
 #define PACKAGE_KEY "_sol.package"
 
 inline int lua_absindex(lua_State *L, int i) {
-	if (i < 0 && i > LUA_REGISTRYINDEX)
-		i += lua_gettop(L) + 1;
-	return i;
+    if (i < 0 && i > LUA_REGISTRYINDEX)
+        i += lua_gettop(L) + 1;
+    return i;
 }
 
 inline void lua_copy(lua_State *L, int from, int to) {
-	int abs_to = lua_absindex(L, to);
-	luaL_checkstack(L, 1, "not enough stack slots");
-	lua_pushvalue(L, from);
-	lua_replace(L, abs_to);
+    int abs_to = lua_absindex(L, to);
+    luaL_checkstack(L, 1, "not enough stack slots");
+    lua_pushvalue(L, from);
+    lua_replace(L, abs_to);
 }
 
 inline void lua_rawgetp(lua_State *L, int i, const void *p) {
-	int abs_i = lua_absindex(L, i);
-	lua_pushlightuserdata(L, (void*)p);
-	lua_rawget(L, abs_i);
+    int abs_i = lua_absindex(L, i);
+    lua_pushlightuserdata(L, (void*)p);
+    lua_rawget(L, abs_i);
 }
 
 inline void lua_rawsetp(lua_State *L, int i, const void *p) {
-	int abs_i = lua_absindex(L, i);
-	luaL_checkstack(L, 1, "not enough stack slots");
-	lua_pushlightuserdata(L, (void*)p);
-	lua_insert(L, -2);
-	lua_rawset(L, abs_i);
+    int abs_i = lua_absindex(L, i);
+    luaL_checkstack(L, 1, "not enough stack slots");
+    lua_pushlightuserdata(L, (void*)p);
+    lua_insert(L, -2);
+    lua_rawset(L, abs_i);
 }
 
 inline void *luaL_testudata(lua_State *L, int i, const char *tname) {
-	void *p = lua_touserdata(L, i);
-	luaL_checkstack(L, 2, "not enough stack slots");
-	if (p == NULL || !lua_getmetatable(L, i))
-		return NULL;
-	else {
-		int res = 0;
-		luaL_getmetatable(L, tname);
-		res = lua_rawequal(L, -1, -2);
-		lua_pop(L, 2);
-		if (!res)
-			p = NULL;
-	}
-	return p;
+    void *p = lua_touserdata(L, i);
+    luaL_checkstack(L, 2, "not enough stack slots");
+    if (p == NULL || !lua_getmetatable(L, i))
+        return NULL;
+    else {
+        int res = 0;
+        luaL_getmetatable(L, tname);
+        res = lua_rawequal(L, -1, -2);
+        lua_pop(L, 2);
+        if (!res)
+            p = NULL;
+    }
+    return p;
 }
 
 inline lua_Number lua_tonumberx(lua_State *L, int i, int *isnum) {
-	lua_Number n = lua_tonumber(L, i);
-	if (isnum != NULL) {
-		*isnum = (n != 0 || lua_isnumber(L, i));
-	}
-	return n;
+    lua_Number n = lua_tonumber(L, i);
+    if (isnum != NULL) {
+        *isnum = (n != 0 || lua_isnumber(L, i));
+    }
+    return n;
 }
 
 inline static void push_package_table(lua_State *L) {
-	lua_pushliteral(L, PACKAGE_KEY);
-	lua_rawget(L, LUA_REGISTRYINDEX);
-	if (!lua_istable(L, -1)) {
-		lua_pop(L, 1);
-		/* try to get package table from globals */
-		lua_pushliteral(L, "package");
-		lua_rawget(L, LUA_GLOBALSINDEX);
-		if (lua_istable(L, -1)) {
-			lua_pushliteral(L, PACKAGE_KEY);
-			lua_pushvalue(L, -2);
-			lua_rawset(L, LUA_REGISTRYINDEX);
-		}
-	}
+    lua_pushliteral(L, PACKAGE_KEY);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        /* try to get package table from globals */
+        lua_pushliteral(L, "package");
+        lua_rawget(L, LUA_GLOBALSINDEX);
+        if (lua_istable(L, -1)) {
+            lua_pushliteral(L, PACKAGE_KEY);
+            lua_pushvalue(L, -2);
+            lua_rawset(L, LUA_REGISTRYINDEX);
+        }
+    }
 }
 
 inline void lua_getuservalue(lua_State *L, int i) {
-	luaL_checktype(L, i, LUA_TUSERDATA);
-	luaL_checkstack(L, 2, "not enough stack slots");
-	lua_getfenv(L, i);
-	lua_pushvalue(L, LUA_GLOBALSINDEX);
-	if (lua_rawequal(L, -1, -2)) {
-		lua_pop(L, 1);
-		lua_pushnil(L);
-		lua_replace(L, -2);
-	}
-	else {
-		lua_pop(L, 1);
-		push_package_table(L);
-		if (lua_rawequal(L, -1, -2)) {
-			lua_pop(L, 1);
-			lua_pushnil(L);
-			lua_replace(L, -2);
-		}
-		else
-			lua_pop(L, 1);
-	}
+    luaL_checktype(L, i, LUA_TUSERDATA);
+    luaL_checkstack(L, 2, "not enough stack slots");
+    lua_getfenv(L, i);
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    if (lua_rawequal(L, -1, -2)) {
+        lua_pop(L, 1);
+        lua_pushnil(L);
+        lua_replace(L, -2);
+    }
+    else {
+        lua_pop(L, 1);
+        push_package_table(L);
+        if (lua_rawequal(L, -1, -2)) {
+            lua_pop(L, 1);
+            lua_pushnil(L);
+            lua_replace(L, -2);
+        }
+        else
+            lua_pop(L, 1);
+    }
 }
 
 inline void lua_setuservalue(lua_State *L, int i) {
-	luaL_checktype(L, i, LUA_TUSERDATA);
-	if (lua_isnil(L, -1)) {
-		luaL_checkstack(L, 1, "not enough stack slots");
-		lua_pushvalue(L, LUA_GLOBALSINDEX);
-		lua_replace(L, -2);
-	}
-	lua_setfenv(L, i);
+    luaL_checktype(L, i, LUA_TUSERDATA);
+    if (lua_isnil(L, -1)) {
+        luaL_checkstack(L, 1, "not enough stack slots");
+        lua_pushvalue(L, LUA_GLOBALSINDEX);
+        lua_replace(L, -2);
+    }
+    lua_setfenv(L, i);
 }
 
 /*
 ** Adapted from Lua 5.2.0
 */
 inline void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
-	luaL_checkstack(L, nup + 1, "too many upvalues");
-	for (; l->name != NULL; l++) {  /* fill the table with given functions */
-		int i;
-		lua_pushstring(L, l->name);
-		for (i = 0; i < nup; i++)  /* copy upvalues to the top */
-			lua_pushvalue(L, -(nup + 1));
-		lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
-		lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
-	}
-	lua_pop(L, nup);  /* remove upvalues */
+    luaL_checkstack(L, nup + 1, "too many upvalues");
+    for (; l->name != NULL; l++) {  /* fill the table with given functions */
+        int i;
+        lua_pushstring(L, l->name);
+        for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+            lua_pushvalue(L, -(nup + 1));
+        lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+        lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
+    }
+    lua_pop(L, nup);  /* remove upvalues */
 }
 
 inline void luaL_setmetatable(lua_State *L, const char *tname) {
-	luaL_checkstack(L, 1, "not enough stack slots");
-	luaL_getmetatable(L, tname);
-	lua_setmetatable(L, -2);
+    luaL_checkstack(L, 1, "not enough stack slots");
+    luaL_getmetatable(L, tname);
+    lua_setmetatable(L, -2);
 }
 
 inline int luaL_getsubtable(lua_State *L, int i, const char *name) {
-	int abs_i = lua_absindex(L, i);
-	luaL_checkstack(L, 3, "not enough stack slots");
-	lua_pushstring(L, name);
-	lua_gettable(L, abs_i);
-	if (lua_istable(L, -1))
-		return 1;
-	lua_pop(L, 1);
-	lua_newtable(L);
-	lua_pushstring(L, name);
-	lua_pushvalue(L, -2);
-	lua_settable(L, abs_i);
-	return 0;
+    int abs_i = lua_absindex(L, i);
+    luaL_checkstack(L, 3, "not enough stack slots");
+    lua_pushstring(L, name);
+    lua_gettable(L, abs_i);
+    if (lua_istable(L, -1))
+        return 1;
+    lua_pop(L, 1);
+    lua_newtable(L);
+    lua_pushstring(L, name);
+    lua_pushvalue(L, -2);
+    lua_settable(L, abs_i);
+    return 0;
 }
 
 #ifndef SOL_LUAJIT
 inline static int countlevels(lua_State *L) {
-	lua_Debug ar;
-	int li = 1, le = 1;
-	/* find an upper bound */
-	while (lua_getstack(L, le, &ar)) { li = le; le *= 2; }
-	/* do a binary search */
-	while (li < le) {
-		int m = (li + le) / 2;
-		if (lua_getstack(L, m, &ar)) li = m + 1;
-		else le = m;
-	}
-	return le - 1;
+    lua_Debug ar;
+    int li = 1, le = 1;
+    /* find an upper bound */
+    while (lua_getstack(L, le, &ar)) { li = le; le *= 2; }
+    /* do a binary search */
+    while (li < le) {
+        int m = (li + le) / 2;
+        if (lua_getstack(L, m, &ar)) li = m + 1;
+        else le = m;
+    }
+    return le - 1;
 }
 
 inline static int findfield(lua_State *L, int objidx, int level) {
-	if (level == 0 || !lua_istable(L, -1))
-		return 0;  /* not found */
-	lua_pushnil(L);  /* start 'next' loop */
-	while (lua_next(L, -2)) {  /* for each pair in table */
-		if (lua_type(L, -2) == LUA_TSTRING) {  /* ignore non-string keys */
-			if (lua_rawequal(L, objidx, -1)) {  /* found object? */
-				lua_pop(L, 1);  /* remove value (but keep name) */
-				return 1;
-			}
-			else if (findfield(L, objidx, level - 1)) {  /* try recursively */
-				lua_remove(L, -2);  /* remove table (but keep name) */
-				lua_pushliteral(L, ".");
-				lua_insert(L, -2);  /* place '.' between the two names */
-				lua_concat(L, 3);
-				return 1;
-			}
-		}
-		lua_pop(L, 1);  /* remove value */
-	}
-	return 0;  /* not found */
+    if (level == 0 || !lua_istable(L, -1))
+        return 0;  /* not found */
+    lua_pushnil(L);  /* start 'next' loop */
+    while (lua_next(L, -2)) {  /* for each pair in table */
+        if (lua_type(L, -2) == LUA_TSTRING) {  /* ignore non-string keys */
+            if (lua_rawequal(L, objidx, -1)) {  /* found object? */
+                lua_pop(L, 1);  /* remove value (but keep name) */
+                return 1;
+            }
+            else if (findfield(L, objidx, level - 1)) {  /* try recursively */
+                lua_remove(L, -2);  /* remove table (but keep name) */
+                lua_pushliteral(L, ".");
+                lua_insert(L, -2);  /* place '.' between the two names */
+                lua_concat(L, 3);
+                return 1;
+            }
+        }
+        lua_pop(L, 1);  /* remove value */
+    }
+    return 0;  /* not found */
 }
 
 inline static int pushglobalfuncname(lua_State *L, lua_Debug *ar) {
-	int top = lua_gettop(L);
-	lua_getinfo(L, "f", ar);  /* push function */
-	lua_pushvalue(L, LUA_GLOBALSINDEX);
-	if (findfield(L, top + 1, 2)) {
-		lua_copy(L, -1, top + 1);  /* move name to proper place */
-		lua_pop(L, 2);  /* remove pushed values */
-		return 1;
-	}
-	else {
-		lua_settop(L, top);  /* remove function and global table */
-		return 0;
-	}
+    int top = lua_gettop(L);
+    lua_getinfo(L, "f", ar);  /* push function */
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    if (findfield(L, top + 1, 2)) {
+        lua_copy(L, -1, top + 1);  /* move name to proper place */
+        lua_pop(L, 2);  /* remove pushed values */
+        return 1;
+    }
+    else {
+        lua_settop(L, top);  /* remove function and global table */
+        return 0;
+    }
 }
 
 inline static void pushfuncname(lua_State *L, lua_Debug *ar) {
-	if (*ar->namewhat != '\0')  /* is there a name? */
-		lua_pushfstring(L, "function " LUA_QS, ar->name);
-	else if (*ar->what == 'm')  /* main? */
-		lua_pushliteral(L, "main chunk");
-	else if (*ar->what == 'C') {
-		if (pushglobalfuncname(L, ar)) {
-			lua_pushfstring(L, "function " LUA_QS, lua_tostring(L, -1));
-			lua_remove(L, -2);  /* remove name */
-		}
-		else
-			lua_pushliteral(L, "?");
-	}
-	else
-		lua_pushfstring(L, "function <%s:%d>", ar->short_src, ar->linedefined);
+    if (*ar->namewhat != '\0')  /* is there a name? */
+        lua_pushfstring(L, "function " LUA_QS, ar->name);
+    else if (*ar->what == 'm')  /* main? */
+        lua_pushliteral(L, "main chunk");
+    else if (*ar->what == 'C') {
+        if (pushglobalfuncname(L, ar)) {
+            lua_pushfstring(L, "function " LUA_QS, lua_tostring(L, -1));
+            lua_remove(L, -2);  /* remove name */
+        }
+        else
+            lua_pushliteral(L, "?");
+    }
+    else
+        lua_pushfstring(L, "function <%s:%d>", ar->short_src, ar->linedefined);
 }
 
 #define LEVELS1 12  /* size of the first part of the stack */
 #define LEVELS2 10  /* size of the second part of the stack */
 
 inline void luaL_traceback(lua_State *L, lua_State *L1,
-	const char *msg, int level) {
-	lua_Debug ar;
-	int top = lua_gettop(L);
-	int numlevels = countlevels(L1);
-	int mark = (numlevels > LEVELS1 + LEVELS2) ? LEVELS1 : 0;
-	if (msg) lua_pushfstring(L, "%s\n", msg);
-	lua_pushliteral(L, "stack traceback:");
-	while (lua_getstack(L1, level++, &ar)) {
-		if (level == mark) {  /* too many levels? */
-			lua_pushliteral(L, "\n\t...");  /* add a '...' */
-			level = numlevels - LEVELS2;  /* and skip to last ones */
-		}
-		else {
-			lua_getinfo(L1, "Slnt", &ar);
-			lua_pushfstring(L, "\n\t%s:", ar.short_src);
-			if (ar.currentline > 0)
-				lua_pushfstring(L, "%d:", ar.currentline);
-			lua_pushliteral(L, " in ");
-			pushfuncname(L, &ar);
-			lua_concat(L, lua_gettop(L) - top);
-		}
-	}
-	lua_concat(L, lua_gettop(L) - top);
+    const char *msg, int level) {
+    lua_Debug ar;
+    int top = lua_gettop(L);
+    int numlevels = countlevels(L1);
+    int mark = (numlevels > LEVELS1 + LEVELS2) ? LEVELS1 : 0;
+    if (msg) lua_pushfstring(L, "%s\n", msg);
+    lua_pushliteral(L, "stack traceback:");
+    while (lua_getstack(L1, level++, &ar)) {
+        if (level == mark) {  /* too many levels? */
+            lua_pushliteral(L, "\n\t...");  /* add a '...' */
+            level = numlevels - LEVELS2;  /* and skip to last ones */
+        }
+        else {
+            lua_getinfo(L1, "Slnt", &ar);
+            lua_pushfstring(L, "\n\t%s:", ar.short_src);
+            if (ar.currentline > 0)
+                lua_pushfstring(L, "%d:", ar.currentline);
+            lua_pushliteral(L, " in ");
+            pushfuncname(L, &ar);
+            lua_concat(L, lua_gettop(L) - top);
+        }
+    }
+    lua_concat(L, lua_gettop(L) - top);
 }
 #endif
 
 
 inline void luaL_checkversion(lua_State *L) {
-	(void)L;
+    (void)L;
 }
 
 #ifndef SOL_LUAJIT
 inline int luaL_fileresult(lua_State *L, int stat, const char *fname) {
-	int en = errno;  /* calls to Lua API may change this value */
-	if (stat) {
-		lua_pushboolean(L, 1);
-		return 1;
-	}
-	else {
-		lua_pushnil(L);
-		if (fname)
-			lua_pushfstring(L, "%s: %s", fname, strerror(en));
-		else
-			lua_pushstring(L, strerror(en));
-		lua_pushnumber(L, (lua_Number)en);
-		return 3;
-	}
+    int en = errno;  /* calls to Lua API may change this value */
+    if (stat) {
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+    else {
+        lua_pushnil(L);
+        if (fname)
+            lua_pushfstring(L, "%s: %s", fname, strerror(en));
+        else
+            lua_pushstring(L, strerror(en));
+        lua_pushnumber(L, (lua_Number)en);
+        return 3;
+    }
 }
 #endif // luajit
 #endif // Lua 5.0 or Lua 5.1
@@ -309,17 +309,17 @@ typedef LUAI_INT32 LUA_INT32;
 /********************************************************************/
 
 #if !defined(LUA_ANSI) && defined(_WIN32) && !defined(_WIN32_WCE)
-#define LUA_WIN		/* enable goodies for regular Windows platforms */
+#define LUA_WIN        /* enable goodies for regular Windows platforms */
 #endif
 
 
-#if defined(LUA_NUMBER_DOUBLE) && !defined(LUA_ANSI)	/* { */
+#if defined(LUA_NUMBER_DOUBLE) && !defined(LUA_ANSI)    /* { */
 
 /* Microsoft compiler on a Pentium (32 bit) ? */
-#if defined(LUA_WIN) && defined(_MSC_VER) && defined(_M_IX86)	/* { */
+#if defined(LUA_WIN) && defined(_MSC_VER) && defined(_M_IX86)    /* { */
 
 #define LUA_MSASMTRICK
-#define LUA_IEEEENDIAN		0
+#define LUA_IEEEENDIAN        0
 #define LUA_NANTRICK
 
 /* pentium 32 bits? */
@@ -327,28 +327,28 @@ typedef LUAI_INT32 LUA_INT32;
 
 #define LUA_IEEE754TRICK
 #define LUA_IEEELL
-#define LUA_IEEEENDIAN		0
+#define LUA_IEEEENDIAN        0
 #define LUA_NANTRICK
 
 /* pentium 64 bits? */
-#elif defined(__x86_64)						/* }{ */
+#elif defined(__x86_64)                        /* }{ */
 
 #define LUA_IEEE754TRICK
-#define LUA_IEEEENDIAN		0
+#define LUA_IEEEENDIAN        0
 
-#elif defined(__POWERPC__) || defined(__ppc__)			/* }{ */
+#elif defined(__POWERPC__) || defined(__ppc__)            /* }{ */
 
 #define LUA_IEEE754TRICK
-#define LUA_IEEEENDIAN		1
+#define LUA_IEEEENDIAN        1
 
-#else								/* }{ */
+#else                                /* }{ */
 
 /* assume IEEE754 and a 32-bit integer type */
 #define LUA_IEEE754TRICK
 
-#endif								/* } */
+#endif                                /* } */
 
-#endif							/* } */
+#endif                            /* } */
 
 
 /********************************************************************/
@@ -382,51 +382,51 @@ typedef LUAI_INT32 LUA_INT32;
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *********************************************************************/
 
-#if defined(MS_ASMTRICK) || defined(LUA_MSASMTRICK)	/* { */
+#if defined(MS_ASMTRICK) || defined(LUA_MSASMTRICK)    /* { */
 /* trick with Microsoft assembler for X86 */
 
 #define lua_number2unsigned(i,n)  \
   {__int64 l; __asm {__asm fld n   __asm fistp l} i = (unsigned int)l;}
 
 
-#elif defined(LUA_IEEE754TRICK)		/* }{ */
+#elif defined(LUA_IEEE754TRICK)        /* }{ */
 /* the next trick should work on any machine using IEEE754 with
 a 32-bit int type */
 
 union compat52_luai_Cast { double l_d; LUA_INT32 l_p[2]; };
 
-#if !defined(LUA_IEEEENDIAN)	/* { */
-#define LUAI_EXTRAIEEE	\
+#if !defined(LUA_IEEEENDIAN)    /* { */
+#define LUAI_EXTRAIEEE    \
   static const union compat52_luai_Cast ieeeendian = {-(33.0 + 6755399441055744.0)};
-#define LUA_IEEEENDIANLOC	(ieeeendian.l_p[1] == 33)
+#define LUA_IEEEENDIANLOC    (ieeeendian.l_p[1] == 33)
 #else
-#define LUA_IEEEENDIANLOC	LUA_IEEEENDIAN
-#define LUAI_EXTRAIEEE		/* empty */
-#endif				/* } */
+#define LUA_IEEEENDIANLOC    LUA_IEEEENDIAN
+#define LUAI_EXTRAIEEE        /* empty */
+#endif                /* } */
 
 #define lua_number2int32(i,n,t) \
   { LUAI_EXTRAIEEE \
     volatile union compat52_luai_Cast u; u.l_d = (n) + 6755399441055744.0; \
     (i) = (t)u.l_p[LUA_IEEEENDIANLOC]; }
 
-#define lua_number2unsigned(i,n)	lua_number2int32(i, n, lua_Unsigned)
+#define lua_number2unsigned(i,n)    lua_number2int32(i, n, lua_Unsigned)
 
-#endif				/* } */
+#endif                /* } */
 
 
 /* the following definitions always work, but may be slow */
 
-#if !defined(lua_number2unsigned)	/* { */
+#if !defined(lua_number2unsigned)    /* { */
 /* the following definition assures proper modulo behavior */
 #if defined(LUA_NUMBER_DOUBLE) || defined(LUA_NUMBER_FLOAT)
 #include <math.h>
-#define SUPUNSIGNED	((lua_Number)(~(lua_Unsigned)0) + 1)
+#define SUPUNSIGNED    ((lua_Number)(~(lua_Unsigned)0) + 1)
 #define lua_number2unsigned(i,n)  \
-	((i)=(lua_Unsigned)((n) - floor((n)/SUPUNSIGNED)*SUPUNSIGNED))
+    ((i)=(lua_Unsigned)((n) - floor((n)/SUPUNSIGNED)*SUPUNSIGNED))
 #else
-#define lua_number2unsigned(i,n)	((i)=(lua_Unsigned)(n))
+#define lua_number2unsigned(i,n)    ((i)=(lua_Unsigned)(n))
 #endif
-#endif				/* } */
+#endif                /* } */
 
 
 #if !defined(lua_unsigned2number)
@@ -439,238 +439,238 @@ so it may be worth to avoid */
 /********************************************************************/
 
 inline static void compat52_call_lua(lua_State *L, char const code[], size_t len,
-	int nargs, int nret) {
-	lua_rawgetp(L, LUA_REGISTRYINDEX, (void*)code);
-	if (lua_type(L, -1) != LUA_TFUNCTION) {
-		lua_pop(L, 1);
-		if (luaL_loadbuffer(L, code, len, "=none"))
-			lua_error(L);
-		lua_pushvalue(L, -1);
-		lua_rawsetp(L, LUA_REGISTRYINDEX, (void*)code);
-	}
-	lua_insert(L, -nargs - 1);
-	lua_call(L, nargs, nret);
+    int nargs, int nret) {
+    lua_rawgetp(L, LUA_REGISTRYINDEX, (void*)code);
+    if (lua_type(L, -1) != LUA_TFUNCTION) {
+        lua_pop(L, 1);
+        if (luaL_loadbuffer(L, code, len, "=none"))
+            lua_error(L);
+        lua_pushvalue(L, -1);
+        lua_rawsetp(L, LUA_REGISTRYINDEX, (void*)code);
+    }
+    lua_insert(L, -nargs - 1);
+    lua_call(L, nargs, nret);
 }
 
 static const char compat52_arith_code[] = {
-	"local op,a,b=...\n"
-	"if op==0 then return a+b\n"
-	"elseif op==1 then return a-b\n"
-	"elseif op==2 then return a*b\n"
-	"elseif op==3 then return a/b\n"
-	"elseif op==4 then return a%b\n"
-	"elseif op==5 then return a^b\n"
-	"elseif op==6 then return -a\n"
-	"end\n"
+    "local op,a,b=...\n"
+    "if op==0 then return a+b\n"
+    "elseif op==1 then return a-b\n"
+    "elseif op==2 then return a*b\n"
+    "elseif op==3 then return a/b\n"
+    "elseif op==4 then return a%b\n"
+    "elseif op==5 then return a^b\n"
+    "elseif op==6 then return -a\n"
+    "end\n"
 };
 
 inline void lua_arith(lua_State *L, int op) {
-	if (op < LUA_OPADD || op > LUA_OPUNM)
-		luaL_error(L, "invalid 'op' argument for lua_arith");
-	luaL_checkstack(L, 5, "not enough stack slots");
-	if (op == LUA_OPUNM)
-		lua_pushvalue(L, -1);
-	lua_pushnumber(L, op);
-	lua_insert(L, -3);
-	compat52_call_lua(L, compat52_arith_code,
-		sizeof(compat52_arith_code) - 1, 3, 1);
+    if (op < LUA_OPADD || op > LUA_OPUNM)
+        luaL_error(L, "invalid 'op' argument for lua_arith");
+    luaL_checkstack(L, 5, "not enough stack slots");
+    if (op == LUA_OPUNM)
+        lua_pushvalue(L, -1);
+    lua_pushnumber(L, op);
+    lua_insert(L, -3);
+    compat52_call_lua(L, compat52_arith_code,
+        sizeof(compat52_arith_code) - 1, 3, 1);
 }
 
 static const char compat52_compare_code[] = {
-	"local a,b=...\n"
-	"return a<=b\n"
+    "local a,b=...\n"
+    "return a<=b\n"
 };
 
 inline int lua_compare(lua_State *L, int idx1, int idx2, int op) {
-	int result = 0;
-	switch (op) {
-	case LUA_OPEQ:
-		return lua_equal(L, idx1, idx2);
-	case LUA_OPLT:
-		return lua_lessthan(L, idx1, idx2);
-	case LUA_OPLE:
-		luaL_checkstack(L, 5, "not enough stack slots");
-		idx1 = lua_absindex(L, idx1);
-		idx2 = lua_absindex(L, idx2);
-		lua_pushvalue(L, idx1);
-		lua_pushvalue(L, idx2);
-		compat52_call_lua(L, compat52_compare_code,
-			sizeof(compat52_compare_code) - 1, 2, 1);
-		result = lua_toboolean(L, -1);
-		lua_pop(L, 1);
-		return result;
-	default:
-		luaL_error(L, "invalid 'op' argument for lua_compare");
-	}
-	return 0;
+    int result = 0;
+    switch (op) {
+    case LUA_OPEQ:
+        return lua_equal(L, idx1, idx2);
+    case LUA_OPLT:
+        return lua_lessthan(L, idx1, idx2);
+    case LUA_OPLE:
+        luaL_checkstack(L, 5, "not enough stack slots");
+        idx1 = lua_absindex(L, idx1);
+        idx2 = lua_absindex(L, idx2);
+        lua_pushvalue(L, idx1);
+        lua_pushvalue(L, idx2);
+        compat52_call_lua(L, compat52_compare_code,
+            sizeof(compat52_compare_code) - 1, 2, 1);
+        result = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return result;
+    default:
+        luaL_error(L, "invalid 'op' argument for lua_compare");
+    }
+    return 0;
 }
 
 inline void lua_pushunsigned(lua_State *L, lua_Unsigned n) {
-	lua_pushnumber(L, lua_unsigned2number(n));
+    lua_pushnumber(L, lua_unsigned2number(n));
 }
 
 inline lua_Unsigned luaL_checkunsigned(lua_State *L, int i) {
-	lua_Unsigned result;
-	lua_Number n = lua_tonumber(L, i);
-	if (n == 0 && !lua_isnumber(L, i))
-		luaL_checktype(L, i, LUA_TNUMBER);
-	lua_number2unsigned(result, n);
-	return result;
+    lua_Unsigned result;
+    lua_Number n = lua_tonumber(L, i);
+    if (n == 0 && !lua_isnumber(L, i))
+        luaL_checktype(L, i, LUA_TNUMBER);
+    lua_number2unsigned(result, n);
+    return result;
 }
 
 inline lua_Unsigned lua_tounsignedx(lua_State *L, int i, int *isnum) {
-	lua_Unsigned result;
-	lua_Number n = lua_tonumberx(L, i, isnum);
-	lua_number2unsigned(result, n);
-	return result;
+    lua_Unsigned result;
+    lua_Number n = lua_tonumberx(L, i, isnum);
+    lua_number2unsigned(result, n);
+    return result;
 }
 
 inline lua_Unsigned luaL_optunsigned(lua_State *L, int i, lua_Unsigned def) {
-	return luaL_opt(L, luaL_checkunsigned, i, def);
+    return luaL_opt(L, luaL_checkunsigned, i, def);
 }
 
 inline lua_Integer lua_tointegerx(lua_State *L, int i, int *isnum) {
-	lua_Integer n = lua_tointeger(L, i);
-	if (isnum != NULL) {
-		*isnum = (n != 0 || lua_isnumber(L, i));
-	}
-	return n;
+    lua_Integer n = lua_tointeger(L, i);
+    if (isnum != NULL) {
+        *isnum = (n != 0 || lua_isnumber(L, i));
+    }
+    return n;
 }
 
 inline void lua_len(lua_State *L, int i) {
-	switch (lua_type(L, i)) {
-	case LUA_TSTRING: /* fall through */
-	case LUA_TTABLE:
-		if (!luaL_callmeta(L, i, "__len"))
-			lua_pushnumber(L, (int)lua_objlen(L, i));
-		break;
-	case LUA_TUSERDATA:
-		if (luaL_callmeta(L, i, "__len"))
-			break;
-		/* maybe fall through */
-	default:
-		luaL_error(L, "attempt to get length of a %s value",
-			lua_typename(L, lua_type(L, i)));
-	}
+    switch (lua_type(L, i)) {
+    case LUA_TSTRING: /* fall through */
+    case LUA_TTABLE:
+        if (!luaL_callmeta(L, i, "__len"))
+            lua_pushnumber(L, (int)lua_objlen(L, i));
+        break;
+    case LUA_TUSERDATA:
+        if (luaL_callmeta(L, i, "__len"))
+            break;
+        /* maybe fall through */
+    default:
+        luaL_error(L, "attempt to get length of a %s value",
+            lua_typename(L, lua_type(L, i)));
+    }
 }
 
 inline int luaL_len(lua_State *L, int i) {
-	int res = 0, isnum = 0;
-	luaL_checkstack(L, 1, "not enough stack slots");
-	lua_len(L, i);
-	res = (int)lua_tointegerx(L, -1, &isnum);
-	lua_pop(L, 1);
-	if (!isnum)
-		luaL_error(L, "object length is not a number");
-	return res;
+    int res = 0, isnum = 0;
+    luaL_checkstack(L, 1, "not enough stack slots");
+    lua_len(L, i);
+    res = (int)lua_tointegerx(L, -1, &isnum);
+    lua_pop(L, 1);
+    if (!isnum)
+        luaL_error(L, "object length is not a number");
+    return res;
 }
 
 inline const char *luaL_tolstring(lua_State *L, int idx, size_t *len) {
-	if (!luaL_callmeta(L, idx, "__tostring")) {
-		int t = lua_type(L, idx);
-		switch (t) {
-		case LUA_TNIL:
-			lua_pushliteral(L, "nil");
-			break;
-		case LUA_TSTRING:
-		case LUA_TNUMBER:
-			lua_pushvalue(L, idx);
-			break;
-		case LUA_TBOOLEAN:
-			if (lua_toboolean(L, idx))
-				lua_pushliteral(L, "true");
-			else
-				lua_pushliteral(L, "false");
-			break;
-		default:
-			lua_pushfstring(L, "%s: %p", lua_typename(L, t),
-				lua_topointer(L, idx));
-			break;
-		}
-	}
-	return lua_tolstring(L, -1, len);
+    if (!luaL_callmeta(L, idx, "__tostring")) {
+        int t = lua_type(L, idx);
+        switch (t) {
+        case LUA_TNIL:
+            lua_pushliteral(L, "nil");
+            break;
+        case LUA_TSTRING:
+        case LUA_TNUMBER:
+            lua_pushvalue(L, idx);
+            break;
+        case LUA_TBOOLEAN:
+            if (lua_toboolean(L, idx))
+                lua_pushliteral(L, "true");
+            else
+                lua_pushliteral(L, "false");
+            break;
+        default:
+            lua_pushfstring(L, "%s: %p", lua_typename(L, t),
+                lua_topointer(L, idx));
+            break;
+        }
+    }
+    return lua_tolstring(L, -1, len);
 }
 
 inline void luaL_requiref(lua_State *L, char const* modname,
-	lua_CFunction openf, int glb) {
-	luaL_checkstack(L, 3, "not enough stack slots");
-	lua_pushcfunction(L, openf);
-	lua_pushstring(L, modname);
-	lua_call(L, 1, 1);
-	lua_getglobal(L, "package");
-	if (lua_istable(L, -1) == 0) {
-		lua_pop(L, 1);
-		lua_createtable(L, 0, 16);
-		lua_setglobal(L, "package");
-		lua_getglobal(L, "package");
-	}
-	lua_getfield(L, -1, "loaded");
-	if (lua_istable(L, -1) == 0) {
-		lua_pop(L, 1);
-		lua_createtable(L, 0, 1);
-		lua_setfield(L, -2, "loaded");
-		lua_getfield(L, -1, "loaded");
-	}
-	lua_replace(L, -2);
-	lua_pushvalue(L, -2);
-	lua_setfield(L, -2, modname);
-	lua_pop(L, 1);
-	if (glb) {
-		lua_pushvalue(L, -1);
-		lua_setglobal(L, modname);
-	}
+    lua_CFunction openf, int glb) {
+    luaL_checkstack(L, 3, "not enough stack slots");
+    lua_pushcfunction(L, openf);
+    lua_pushstring(L, modname);
+    lua_call(L, 1, 1);
+    lua_getglobal(L, "package");
+    if (lua_istable(L, -1) == 0) {
+        lua_pop(L, 1);
+        lua_createtable(L, 0, 16);
+        lua_setglobal(L, "package");
+        lua_getglobal(L, "package");
+    }
+    lua_getfield(L, -1, "loaded");
+    if (lua_istable(L, -1) == 0) {
+        lua_pop(L, 1);
+        lua_createtable(L, 0, 1);
+        lua_setfield(L, -2, "loaded");
+        lua_getfield(L, -1, "loaded");
+    }
+    lua_replace(L, -2);
+    lua_pushvalue(L, -2);
+    lua_setfield(L, -2, modname);
+    lua_pop(L, 1);
+    if (glb) {
+        lua_pushvalue(L, -1);
+        lua_setglobal(L, modname);
+    }
 }
 
 inline void luaL_buffinit(lua_State *L, luaL_Buffer_52 *B) {
-	/* make it crash if used via pointer to a 5.1-style luaL_Buffer */
-	B->b.p = NULL;
-	B->b.L = NULL;
-	B->b.lvl = 0;
-	/* reuse the buffer from the 5.1-style luaL_Buffer though! */
-	B->ptr = B->b.buffer;
-	B->capacity = LUAL_BUFFERSIZE;
-	B->nelems = 0;
-	B->L2 = L;
+    /* make it crash if used via pointer to a 5.1-style luaL_Buffer */
+    B->b.p = NULL;
+    B->b.L = NULL;
+    B->b.lvl = 0;
+    /* reuse the buffer from the 5.1-style luaL_Buffer though! */
+    B->ptr = B->b.buffer;
+    B->capacity = LUAL_BUFFERSIZE;
+    B->nelems = 0;
+    B->L2 = L;
 }
 
 inline char *luaL_prepbuffsize(luaL_Buffer_52 *B, size_t s) {
-	if (B->capacity - B->nelems < s) { /* needs to grow */
-		char* newptr = NULL;
-		size_t newcap = B->capacity * 2;
-		if (newcap - B->nelems < s)
-			newcap = B->nelems + s;
-		if (newcap < B->capacity) /* overflow */
-			luaL_error(B->L2, "buffer too large");
-		newptr = (char*)lua_newuserdata(B->L2, newcap);
-		memcpy(newptr, B->ptr, B->nelems);
-		if (B->ptr != B->b.buffer)
-			lua_replace(B->L2, -2); /* remove old buffer */
-		B->ptr = newptr;
-		B->capacity = newcap;
-	}
-	return B->ptr + B->nelems;
+    if (B->capacity - B->nelems < s) { /* needs to grow */
+        char* newptr = NULL;
+        size_t newcap = B->capacity * 2;
+        if (newcap - B->nelems < s)
+            newcap = B->nelems + s;
+        if (newcap < B->capacity) /* overflow */
+            luaL_error(B->L2, "buffer too large");
+        newptr = (char*)lua_newuserdata(B->L2, newcap);
+        memcpy(newptr, B->ptr, B->nelems);
+        if (B->ptr != B->b.buffer)
+            lua_replace(B->L2, -2); /* remove old buffer */
+        B->ptr = newptr;
+        B->capacity = newcap;
+    }
+    return B->ptr + B->nelems;
 }
 
 inline void luaL_addlstring(luaL_Buffer_52 *B, const char *s, size_t l) {
-	memcpy(luaL_prepbuffsize(B, l), s, l);
-	luaL_addsize(B, l);
+    memcpy(luaL_prepbuffsize(B, l), s, l);
+    luaL_addsize(B, l);
 }
 
 inline void luaL_addvalue(luaL_Buffer_52 *B) {
-	size_t len = 0;
-	const char *s = lua_tolstring(B->L2, -1, &len);
-	if (!s)
-		luaL_error(B->L2, "cannot convert value to string");
-	if (B->ptr != B->b.buffer)
-		lua_insert(B->L2, -2); /* userdata buffer must be at stack top */
-	luaL_addlstring(B, s, len);
-	lua_remove(B->L2, B->ptr != B->b.buffer ? -2 : -1);
+    size_t len = 0;
+    const char *s = lua_tolstring(B->L2, -1, &len);
+    if (!s)
+        luaL_error(B->L2, "cannot convert value to string");
+    if (B->ptr != B->b.buffer)
+        lua_insert(B->L2, -2); /* userdata buffer must be at stack top */
+    luaL_addlstring(B, s, len);
+    lua_remove(B->L2, B->ptr != B->b.buffer ? -2 : -1);
 }
 
 inline void luaL_pushresult(luaL_Buffer_52 *B) {
-	lua_pushlstring(B->L2, B->ptr, B->nelems);
-	if (B->ptr != B->b.buffer)
-		lua_replace(B->L2, -2); /* remove userdata buffer */
+    lua_pushlstring(B->L2, B->ptr, B->nelems);
+    if (B->ptr != B->b.buffer)
+        lua_replace(B->L2, -2); /* remove userdata buffer */
 }
 
 #endif /* SOL_LUA_VERSION == 501 */

--- a/sol/compatibility/version.hpp
+++ b/sol/compatibility/version.hpp
@@ -19,11 +19,25 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOL_HPP
-#define SOL_HPP
+#ifndef SOL_VERSION_HPP
+#define SOL_VERSION_HPP
 
-#include "sol/state.hpp"
-#include "sol/object.hpp"
-#include "sol/function.hpp"
+#include <lua.hpp>
 
-#endif // SOL_HPP
+#ifdef LUAJIT_VERSION
+#define SOL_LUAJIT
+#endif // luajit
+
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 502
+#define SOL_LUA_VERSION LUA_VERSION_NUM
+#elif defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 501
+#define SOL_LUA_VERSION LUA_VERSION_NUM
+#elif !defined(LUA_VERSION_NUM)
+// Definitely 5.0
+#define SOL_LUA_VERSION 500
+#else
+// ??? Not sure, assume 502?
+#define SOL_LUA_VERSION 502
+#endif // Lua Version 502, 501 || luajit, 500 
+
+#endif // SOL_VERSION_HPP

--- a/sol/compatibility/version.hpp
+++ b/sol/compatibility/version.hpp
@@ -25,7 +25,9 @@
 #include <lua.hpp>
 
 #ifdef LUAJIT_VERSION
+#ifndef SOL_LUAJIT
 #define SOL_LUAJIT
+#endif // sol luajit
 #endif // luajit
 
 #if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 502

--- a/sol/debug.hpp
+++ b/sol/debug.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/default_construct.hpp
+++ b/sol/default_construct.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/demangle.hpp
+++ b/sol/demangle.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/demangle.hpp
+++ b/sol/demangle.hpp
@@ -59,7 +59,7 @@ inline std::string demangle(const std::type_info& id) {
         while(found != std::string::npos) {
             realname.erase(found, removals[r].size());
             found = realname.find(removals[r]);
-       }
+        }
     }
 
     for(std::size_t r = 0; r < replacements.size(); r+=2) {

--- a/sol/demangle.hpp
+++ b/sol/demangle.hpp
@@ -26,7 +26,7 @@
 #include <array>
 #include <cstdlib>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
 #include <cxxabi.h>
 #endif
 

--- a/sol/deprecate.hpp
+++ b/sol/deprecate.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/deprecate.hpp
+++ b/sol/deprecate.hpp
@@ -34,10 +34,10 @@
 
 namespace sol {
 namespace detail {
-   template <typename T>
-   struct SOL_DEPRECATED deprecate_type {
-       using type = T;
-   };
+    template <typename T>
+    struct SOL_DEPRECATED deprecate_type {
+        using type = T;
+    };
 } // detail
 } // sol
 

--- a/sol/error.hpp
+++ b/sol/error.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -108,7 +108,10 @@ public:
 
 class function : public reference {
 public:
-    static reference default_handler;
+    static reference& default_handler() {
+        static sol::reference h;
+	   return h;
+    }
 
 private:
     struct handler {
@@ -196,7 +199,7 @@ public:
     sol::reference error_handler;
 
     function() = default;
-    function(lua_State* L, int index = -1): reference(L, index), error_handler(default_handler) {
+    function(lua_State* L, int index = -1): reference(L, index), error_handler(default_handler()) {
         type_assert(L, index, type::function);
     }
     function(const function&) = default;
@@ -225,8 +228,6 @@ public:
         return invoke(tr, tr, pushcount, h);
     }
 };
-
-sol::reference function::default_handler;
 
 namespace stack {
 template<typename... Sigs>

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -80,12 +80,12 @@ public:
     }
 
     template<typename... Ret, typename... Args>
-    typename return_type<Ret...>::type operator()(types<Ret...>, Args&&... args) const {
+    ReturnType<Ret...> operator()(types<Ret...>, Args&&... args) const {
         return call<Ret...>(std::forward<Args>(args)...);
     }
 
     template<typename... Ret, typename... Args>
-    typename return_type<Ret...>::type call(Args&&... args) const {
+    ReturnType<Ret...> call(Args&&... args) const {
         push();
         int pushcount = stack::push_args(state(), std::forward<Args>(args)...);
         auto tr = types<Ret...>();

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -60,25 +60,25 @@ public:
     function_result& operator=(const function_result&) = default;
     function_result(function_result&& o) : L(o.L), index(o.index), returncount(o.returncount), error(o.error) {
         // Must be manual, otherwise destructor will screw us
-	   // return count being 0 is enough to keep things clean
-	   // but will be thorough
-	   o.L = nullptr;
-	   o.index = 0;
-	   o.returncount = 0;
-	   o.error = call_error::runtime;
+        // return count being 0 is enough to keep things clean
+        // but will be thorough
+        o.L = nullptr;
+        o.index = 0;
+        o.returncount = 0;
+        o.error = call_error::runtime;
     }
     function_result& operator=(function_result&& o) {
-	   L = o.L;
-	   index = o.index;
-	   returncount = o.returncount;
-	   error = o.error;
-	   // Must be manual, otherwise destructor will screw us
-	   // return count being 0 is enough to keep things clean
-	   // but will be thorough
-	   o.L = nullptr;
-	   o.index = 0;
-	   o.returncount = 0;
-	   o.error = call_error::runtime;
+        L = o.L;
+        index = o.index;
+        returncount = o.returncount;
+        error = o.error;
+        // Must be manual, otherwise destructor will screw us
+        // return count being 0 is enough to keep things clean
+        // but will be thorough
+        o.L = nullptr;
+        o.index = 0;
+        o.returncount = 0;
+        o.error = call_error::runtime;
     }
 
     bool valid() const {
@@ -91,8 +91,8 @@ public:
         return get(tr, tr);
     }
 
-    operator const char* () const {
-        return get<const char*>();
+    operator std::string() const {
+        return get<std::string>();
     }
 
     template<typename T, EnableIf<Not<std::is_same<Unqualified<T>, const char*>>, Not<std::is_same<Unqualified<T>, char>>, Not<std::is_same<Unqualified<T>, std::string>>, Not<std::is_same<Unqualified<T>, std::initializer_list<char>>>> = 0>
@@ -210,13 +210,13 @@ public:
 
     template<typename... Ret, typename... Args>
     auto operator()(types<Ret...>, Args&&... args) const 
-    -> decltype(call<Ret...>(std::forward<Args>(args)...)) {
+    -> decltype(invoke(types<Ret...>(), types<Ret...>(), 0, std::declval<handler&>())) {
         return call<Ret...>(std::forward<Args>(args)...);
     }
 
     template<typename... Ret, typename... Args>
     auto call(Args&&... args) const
-    -> decltype(invoke(types<Ret...>(), types<Ret...>(), 0, std::declval<handler>())) {
+    -> decltype(invoke(types<Ret...>(), types<Ret...>(), 0, std::declval<handler&>())) {
         handler h(error_handler);
         push();
         int pushcount = stack::push_args(state(), std::forward<Args>(args)...);

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -79,6 +79,7 @@ public:
         o.index = 0;
         o.returncount = 0;
         o.error = call_error::runtime;
+        return *this;
     }
 
     bool valid() const {

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -193,7 +193,7 @@ public:
     sol::reference error_handler;
 
     function() = default;
-    function(lua_State* L, int index = -1): reference(L, index) {
+    function(lua_State* L, int index = -1): reference(L, index), error_handler(default_handler) {
         type_assert(L, index, type::function);
     }
     function(const function&) = default;

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -110,11 +110,11 @@ private:
 
     function_result invoke(indices<>, types<>, std::ptrdiff_t n) const {
         const int stacksize = lua_gettop(state());
-	   const int firstreturn = std::max(0, stacksize - static_cast<int>(n) - 1);
+        const int firstreturn = std::max(0, stacksize - static_cast<int>(n) - 1);
         luacall(n, LUA_MULTRET);
         const int poststacksize = lua_gettop(state());
         const int returncount = poststacksize - firstreturn;
-	   return function_result(state(), firstreturn + 1, returncount);
+        return function_result(state(), firstreturn + 1, returncount);
     }
 
 public:
@@ -172,7 +172,7 @@ struct pusher<function_sig_t<Sigs...>> {
 
     template<typename Sig>
     static void set(lua_State* L, Sig* fxptr){
-       set_fx(std::false_type(), L, fxptr);
+        set_fx(std::false_type(), L, fxptr);
     }
 
     template<typename... Args, typename R, typename C, typename T>

--- a/sol/function.hpp
+++ b/sol/function.hpp
@@ -107,10 +107,19 @@ public:
 };
 
 class function : public reference {
+private:
+	static reference& handler_storage() {
+		static sol::reference h;
+		return h;
+	}
+
 public:
-    static reference& default_handler() {
-        static sol::reference h;
-	   return h;
+    static const reference& get_default_handler () {
+        return handler_storage();
+    }
+
+    static void set_default_handler( reference& ref ) {
+        handler_storage() = ref;
     }
 
 private:
@@ -199,7 +208,7 @@ public:
     sol::reference error_handler;
 
     function() = default;
-    function(lua_State* L, int index = -1): reference(L, index), error_handler(default_handler()) {
+    function(lua_State* L, int index = -1): reference(L, index), error_handler(get_default_handler()) {
         type_assert(L, index, type::function);
     }
     function(const function&) = default;

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -168,7 +168,8 @@ struct static_function {
     template<typename... Ret, typename... Args>
     static int typed_call(types<Ret...>, types<Args...> ta, function_type* fx, lua_State* L) {
         typedef typename return_type<Ret...>::type return_type;
-        decltype(auto) r = stack::call(L, 0, types<return_type>(), ta, fx);
+	   typedef decltype(stack::call(L, 0, types<return_type>(), ta, fx)) ret_t;
+        ret_t r = stack::call(L, 0, types<return_type>(), ta, fx);
         int nargs = static_cast<int>(sizeof...(Args));
         lua_pop(L, nargs);
         return stack::push(L, std::forward<decltype(r)>(r));
@@ -392,7 +393,8 @@ struct member_function : public base_function {
 
     template<typename... Ret, typename... Args>
     int operator()(types<Ret...> tr, types<Args...> ta, lua_State* L) {
-        decltype(auto) r = stack::call(L, 0, tr, ta, fx);
+        typedef decltype(stack::call(L, 0, tr, ta, fx)) ret_t;
+        ret_t r = stack::call(L, 0, tr, ta, fx);
         int nargs = static_cast<int>(sizeof...(Args));
         lua_pop(L, nargs);
         return stack::push(L, std::forward<decltype(r)>(r));
@@ -458,7 +460,8 @@ struct usertype_function_core : public base_function {
 
     template<typename... Ret, typename... Args>
     int call(types<Ret...> tr, types<Args...> ta, lua_State* L) {
-        decltype(auto) r = stack::call(L, 0, tr, ta, fx);
+        typedef decltype(stack::call(L, 0, tr, ta, fx)) ret_t;
+        ret_t r = stack::call(L, 0, tr, ta, fx);
         int nargs = static_cast<int>(sizeof...(Args));
         lua_pop(L, nargs);
         int pushcount = push(L, std::forward<decltype(r)>(r));

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -47,7 +47,7 @@ struct functor {
     functor(FxArgs&&... fxargs): item(nullptr), invocation(std::forward<FxArgs>(fxargs)...) {}
 
     bool check () const {
-         return invocation != nullptr;
+        return invocation != nullptr;
     }
 
     template<typename... Args>

--- a/sol/function_types.hpp
+++ b/sol/function_types.hpp
@@ -351,11 +351,11 @@ struct functor_function : public base_function {
     }
 
     virtual int operator()(lua_State* L) override {
-        return (*this)(tuple_types<return_type>(), args_type(), L);
+        return (*this)(types<return_type>(), args_type(), L);
     }
 
     virtual int operator()(lua_State* L, detail::ref_call_t) override {
-        return (*this)(tuple_types<return_type>(), args_type(), L);
+        return (*this)(types<return_type>(), args_type(), L);
     }
 };
 

--- a/sol/object.hpp
+++ b/sol/object.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -52,7 +52,7 @@ public:
     template<typename... Args>
     proxy& set_function(Args&&... args) {
         tbl.set_function(key, std::forward<Args>(args)...);
-        return *this;
+	   return *this;
     }
 
     template<typename U, EnableIf<Function<Unqualified<U>>> = 0>
@@ -65,49 +65,23 @@ public:
         tbl.set(key, std::forward<U>(other));
     }
 
-    operator nil_t() const {
-        return get<nil_t>();
+    operator const char* () const {
+        return get<const char*>();
     }
 
-    operator object() const {
-        return get<object>();
-    }
-
-    operator function() const {
-        return get<function>();
-    }
-
-    operator Unqualified<Table>() const {
-        return get<Unqualified<Table>>();
-    }
-
-    operator std::string() const {
-        return get<std::string>();
-    }
-
-    template<typename T = void>
-    operator bool() const {
-        return get<bool>();
-    }
-
-    template<typename T = void>
-    operator double() const {
-        return get<double>();
-    }
-
-    template<typename T = void>
-    operator float() const {
-        return get<float>();
-    }
-
-    template<typename T = void>
-    operator int() const {
-        return get<int>();
+    template<typename T, EnableIf<Not<std::is_same<Unqualified<T>, const char*>>, Not<std::is_same<Unqualified<T>, char>>, Not<std::is_same<Unqualified<T>, std::string>>, Not<std::is_same<Unqualified<T>, std::initializer_list<char>>>> = 0>
+    operator T () const {
+        return get<T>();
     }
 
     template<typename... Ret, typename... Args>
-    typename return_type<Ret...>::type call(Args&&... args) {
+    stack::get_return_or<function_result, Ret...> call(Args&&... args) {
         return tbl.template get<function>(key)(types<Ret...>(), std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    function_result operator()(Args&&... args) {
+        return tbl.template get<function>(key)(std::forward<Args>(args)...);
     }
 };
 

--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -67,8 +67,8 @@ public:
         return tbl.template get<T>( key );
     }
 
-    operator const char* () const {
-        return get<const char*>();
+    operator std::string() const {
+        return get<std::string>();
     }
 
     template<typename T, EnableIf<Not<std::is_same<Unqualified<T>, const char*>>, Not<std::is_same<Unqualified<T>, char>>, Not<std::is_same<Unqualified<T>, std::string>>, Not<std::is_same<Unqualified<T>, std::initializer_list<char>>>> = 0>

--- a/sol/proxy.hpp
+++ b/sol/proxy.hpp
@@ -31,17 +31,12 @@ template<typename Table, typename Key>
 struct proxy {
 private:
     Table& tbl;
-    Key& key;
+    If<std::is_array<Unqualified<Key>>, Key&, Unqualified<Key>> key;
 
 public:
 
     template<typename T>
     proxy(Table& table, T&& key) : tbl(table), key(std::forward<T>(key)) {}
-
-    template<typename T>
-    T get() const {
-        return tbl.template get<T>(key);
-    }
 
     template<typename T>
     proxy& set(T&& item) {
@@ -56,13 +51,20 @@ public:
     }
 
     template<typename U, EnableIf<Function<Unqualified<U>>> = 0>
-    void operator=(U&& other) {
+    proxy& operator=(U&& other) {
         tbl.set_function(key, std::forward<U>(other));
+        return *this;
     }
 
     template<typename U, DisableIf<Function<Unqualified<U>>> = 0>
-    void operator=(U&& other) {
+    proxy& operator=(U&& other) {
         tbl.set(key, std::forward<U>(other));
+        return *this;
+    }
+
+    template<typename T>
+    T get() const {
+        return tbl.template get<T>( key );
     }
 
     operator const char* () const {

--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -48,7 +48,7 @@ public:
 
     int push() const noexcept {
         lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-	   return 1;
+        return 1;
     }
 
     reference(reference&& o) noexcept {

--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -31,6 +31,8 @@ private:
     int ref = LUA_NOREF;
 
     int copy() const {
+        if (ref == LUA_NOREF)
+            return LUA_NOREF;
         push();
         return luaL_ref(L, LUA_REGISTRYINDEX);
     }
@@ -44,11 +46,6 @@ public:
 
     virtual ~reference() {
         luaL_unref(L, LUA_REGISTRYINDEX, ref);
-    }
-
-    int push() const noexcept {
-        lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-        return 1;
     }
 
     reference(reference&& o) noexcept {
@@ -78,6 +75,19 @@ public:
         L = o.L;
         ref = o.copy();
         return *this;
+    }
+
+    int push() const noexcept {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+        return 1;
+    }
+
+    int get_index() const {
+        return ref;
+    }
+
+    bool valid () const {
+        return !(ref == LUA_NOREF);
     }
 
     type get_type() const {

--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -46,8 +46,9 @@ public:
         luaL_unref(L, LUA_REGISTRYINDEX, ref);
     }
 
-    void push() const noexcept {
+    int push() const noexcept {
         lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+	   return 1;
     }
 
     reference(reference&& o) noexcept {

--- a/sol/resolve.hpp
+++ b/sol/resolve.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/resolve.hpp
+++ b/sol/resolve.hpp
@@ -43,7 +43,7 @@ inline auto resolve_f(std::true_type, F&& f)
 template<typename F>
 inline void resolve_f(std::false_type, F&&) {
     static_assert(has_deducible_signature<F>::value,
-                  "Cannot use no-template-parameter call with an overloaded functor: specify the signature");
+                    "Cannot use no-template-parameter call with an overloaded functor: specify the signature");
 }
 
 template<typename F, typename U = Unqualified<F>>

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -592,22 +592,22 @@ inline void call(lua_State* L, int start, indices<I...>, types<void>, types<Args
 
 template <bool checkargs = detail::default_check_arguments, typename R, typename... Args, typename Fx, typename... FxArgs, typename = typename std::enable_if<!std::is_void<R>::value>::type>
 inline R call(lua_State* L, int start, types<R> tr, types<Args...> ta, Fx&& fx, FxArgs&&... args) {
-    return detail::call(L, start, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
+    return detail::call<checkargs>(L, start, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
 }
 
 template <bool checkargs = detail::default_check_arguments, typename R, typename... Args, typename Fx, typename... FxArgs, typename = typename std::enable_if<!std::is_void<R>::value>::type>
 inline R call(lua_State* L, types<R> tr, types<Args...> ta, Fx&& fx, FxArgs&&... args) {
-    return call(L, 0, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
+    return call<checkargs>(L, 0, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
 }
 
 template <bool checkargs = detail::default_check_arguments, typename... Args, typename Fx, typename... FxArgs>
 inline void call(lua_State* L, int start, types<void> tr, types<Args...> ta, Fx&& fx, FxArgs&&... args) {
-    detail::call(L, start, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
+    detail::call<checkargs>(L, start, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
 }
 
 template <bool checkargs = detail::default_check_arguments, typename... Args, typename Fx, typename... FxArgs>
 inline void call(lua_State* L, types<void> tr, types<Args...> ta, Fx&& fx, FxArgs&&... args) {
-    call(L, 0, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
+    call<checkargs>(L, 0, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);
 }
 
 inline call_syntax get_call_syntax(lua_State* L, const std::string& meta) {

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -575,7 +575,7 @@ inline void call(lua_State* L, int start, indices<I...>, types<void>, types<Args
 }
 } // detail
 
-void remove( lua_State* L, int index, int count ) {
+inline void remove( lua_State* L, int index, int count ) {
     if ( count < 1 )
         return;
     int top = lua_gettop( L );

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -263,9 +263,7 @@ struct getter<T*> {
         type t = type_of(L, index);
         if (t == type::nil)
             return nullptr;
-        void* udata = lua_touserdata(L, index);
-        T** obj = static_cast<T**>(udata);
-        return *obj;
+        return getter<T&>{}.get(L, index);
     }
 };
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -575,6 +575,28 @@ inline void call(lua_State* L, int start, indices<I...>, types<void>, types<Args
 }
 } // detail
 
+void remove( lua_State* L, int index, int count ) {
+    if ( count < 1 )
+        return;
+    int top = lua_gettop( L );
+    if ( index == -1 || top == index ) {
+        // Slice them right off the top
+        lua_pop( L, static_cast<int>(count) );
+        return;
+    }
+
+    // Remove each item one at a time using stack operations
+    // Probably slower, maybe, haven't benchmarked,
+    // but necessary
+    if ( index < 0 ) {
+        index = lua_gettop( L ) + (index + 1);
+    }
+    int last = index + count;
+    for ( int i = index; i < last; ++i ) {
+        lua_remove( L, i );
+    }
+}
+
 template <bool checkargs = detail::default_check_arguments, typename R, typename... Args, typename Fx, typename... FxArgs, typename = typename std::enable_if<!std::is_void<R>::value>::type>
 inline R call(lua_State* L, int start, types<R> tr, types<Args...> ta, Fx&& fx, FxArgs&&... args) {
     return detail::call<checkargs>(L, start, ta, tr, ta, std::forward<Fx>(fx), std::forward<FxArgs>(args)...);

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -378,7 +378,7 @@ struct pusher {
 
     template<typename U = T, EnableIf<std::is_base_of<reference, U>> = 0>
     static int push(lua_State*, T& ref) {
-       return ref.push();
+        return ref.push();
     }
 
     template<typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -113,9 +113,9 @@ inline int push_args(lua_State* L, T&& t, Args&&... args) {
     return pushcount;
 }
 
-template<typename T, typename U = Unqualified<T>>
-inline auto get(lua_State* L, int index = -1) -> decltype(getter<U>{}.get(L, index)) {
-    return getter<U>{}.get(L, index);
+template<typename T>
+inline auto get(lua_State* L, int index = -1) -> decltype(getter<Unqualified<T>>{}.get(L, index)) {
+    return getter<Unqualified<T>>{}.get(L, index);
 }
 
 template<typename T>
@@ -619,7 +619,7 @@ inline void call(lua_State* L, types<void> tr, types<Args...> ta, Fx&& fx, FxArg
 }
 
 inline call_syntax get_call_syntax(lua_State* L, const std::string& meta) {
-    if (get<type>(L, 1) == type::table) {
+    if (sol::stack::get<type>(L, 1) == type::table) {
         if (luaL_newmetatable(L, meta.c_str()) == 0) {
             lua_settop(L, -2);
             return call_syntax::colon;

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -141,6 +141,12 @@ bool check(lua_State* L, int index) {
     return check<T>(L, index, handler);
 }
 
+template<typename... Ret>
+using get_return = ReturnType<decltype(stack::get<Ret>( nullptr, 0 ))...>;
+
+template<typename Empty, typename... Ret>
+using get_return_or = ReturnTypeOr<Empty, decltype(stack::get<Ret>( nullptr, 0 ))...>;
+
 namespace detail {
 const bool default_check_arguments = 
 #ifdef SOL_CHECK_ARGUMENTS
@@ -258,7 +264,7 @@ struct getter<T*> {
         type t = type_of(L, index);
         if (t == type::nil)
             return nullptr;
-        return getter<T&>{}.get(L, index);
+        return std::addressof(getter<T&>{}.get(L, index));
     }
 };
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -130,6 +130,8 @@ template <typename T, typename Handler>
 bool check(lua_State* L, int index, Handler&& handler) {
     typedef Unqualified<T> Tu;
     checker<Tu> c;
+    // VC++ has a bad warning here: shut it up
+    (void)c;
     return c.check(L, index, std::forward<Handler>(handler));
 }
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -262,7 +262,7 @@ struct getter<T*> {
             return nullptr;
         void* udata = lua_touserdata(L, index);
         T** obj = static_cast<T**>(udata);
-       return *obj;
+        return *obj;
     }
 };
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -78,14 +78,14 @@ template <typename T, typename Key>
 inline int push_userdata_pointer(lua_State* L, Key&& metatablekey) {
     return push_confirmed_userdata<T>(L, std::forward<Key>(metatablekey));
 }
-	
+
 template <typename T, typename Key, typename Arg, EnableIf<std::is_same<T, Unqualified<Arg>>> = 0>
 inline int push_userdata_pointer(lua_State* L, Key&& metatablekey, Arg&& arg) {
     if (arg == nullptr)
         return push(L, nil);
     return push_confirmed_userdata<T>(L, std::forward<Key>(metatablekey), std::forward<Arg>(arg));
 }
-	
+
 template <typename T, typename Key, typename Arg, DisableIf<std::is_same<T, Unqualified<Arg>>> = 0>
 inline int push_userdata_pointer(lua_State* L, Key&& metatablekey, Arg&& arg) {
     return push_confirmed_userdata<T>(L, std::forward<Key>(metatablekey), std::forward<Arg>(arg));
@@ -93,17 +93,17 @@ inline int push_userdata_pointer(lua_State* L, Key&& metatablekey, Arg&& arg) {
 
 template <typename T, typename Key, typename Arg0, typename Arg1, typename... Args>
 inline int push_userdata_pointer(lua_State* L, Key&& metatablekey, Arg0&& arg0, Arg1&& arg1, Args&&... args) {
-	return push_confirmed_userdata<T>(L, std::forward<Key>(metatablekey), std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...);
+    return push_confirmed_userdata<T>(L, std::forward<Key>(metatablekey), std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...);
 }
 
 template <typename T, typename Key, typename... Args>
 inline int push_confirmed_userdata(lua_State* L, Key&& metatablekey, Args&&... args) {
-	T* pdatum = static_cast<T*>(lua_newuserdata(L, sizeof(T)));
-	std::allocator<T> alloc{};
-	alloc.construct(pdatum, std::forward<Args>(args)...);
-	luaL_getmetatable(L, std::addressof(metatablekey[0]));
-	lua_setmetatable(L, -2);
-	return 1;
+    T* pdatum = static_cast<T*>(lua_newuserdata(L, sizeof(T)));
+    std::allocator<T> alloc{};
+    alloc.construct(pdatum, std::forward<Args>(args)...);
+    luaL_getmetatable(L, std::addressof(metatablekey[0]));
+    lua_setmetatable(L, -2);
+    return 1;
 }
 
 template<typename T, typename Key, typename... Args, DisableIf<std::is_pointer<T>> = 0>
@@ -193,7 +193,7 @@ struct checker<T*, expected, C> {
     template <typename Handler>
     static bool check (lua_State* L, int index, const Handler& handler) {
         const type indextype = type_of(L, index);
-	   // Allow nil to be transformed to nullptr
+       // Allow nil to be transformed to nullptr
         bool success = expected == indextype || indextype == type::nil;
         if (!success) {
             // expected type, actual type
@@ -255,7 +255,7 @@ struct getter<T*> {
             return nullptr;
         void* udata = lua_touserdata(L, index);
         T** obj = static_cast<T**>(udata);
-	   return *obj;
+       return *obj;
     }
 };
 

--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -192,11 +192,6 @@ inline int push_userdata(lua_State* L, Key&& metatablekey, Args&&... args) {
 }
 } // detail
 
-template<typename T>
-struct get_return {
-    typedef decltype(get<T>(nullptr)) type;
-};
-
 template <typename T, type expected, typename>
 struct checker {
     template <typename Handler>

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -153,7 +153,7 @@ public:
     template<typename... Args, typename... Keys>
     auto get(Keys&&... keys) const
     -> decltype(global.get<Args...>(std::forward<Keys>(keys)...)) {
-       return global.get<Args...>(std::forward<Keys>(keys)...);
+        return global.get<Args...>(std::forward<Keys>(keys)...);
     }
 
     template<typename T, typename U>

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -85,9 +85,9 @@ public:
         for(auto&& library : libraries) {
             switch(library) {
 #if SOL_LUA_VERSION <= 501 && defined(SOL_LUAJIT)
-		  case lib::coroutine:
+            case lib::coroutine:
 #endif // luajit opens coroutine base stuff
-		  case lib::base:
+            case lib::base:
                 luaL_requiref(L.get(), "base", luaopen_base, 1);
                 lua_pop(L.get(), 1);
                 break;

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -96,12 +96,12 @@ public:
                 lua_pop(L.get(), 1);
                 break;
 #if SOL_LUA_VERSION > 501
-		  case lib::coroutine:
+            case lib::coroutine:
                 luaL_requiref(L.get(), "coroutine", luaopen_coroutine, 1);
                 lua_pop(L.get(), 1);
                 break;
 #endif // Lua 5.2+ only
-		  case lib::string:
+            case lib::string:
                 luaL_requiref(L.get(), "string", luaopen_string, 1);
                 lua_pop(L.get(), 1);
                 break;

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -58,7 +58,7 @@ public:
     state():
     L(luaL_newstate(), lua_close),
     reg(L.get(), LUA_REGISTRYINDEX),
-#if SOL_LUA_VERSION < 520
+#if SOL_LUA_VERSION < 503
     // Global table is just a special index
     global(L.get(), LUA_GLOBALSINDEX) {
 #else

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -95,12 +95,12 @@ public:
                 luaL_requiref(L.get(), "package", luaopen_package, 1);
                 lua_pop(L.get(), 1);
                 break;
-#if SOL_LUA_VERSION > 501
             case lib::coroutine:
+#if SOL_LUA_VERSION > 501
                 luaL_requiref(L.get(), "coroutine", luaopen_coroutine, 1);
                 lua_pop(L.get(), 1);
-                break;
 #endif // Lua 5.2+ only
+                break;
             case lib::string:
                 luaL_requiref(L.get(), "string", luaopen_string, 1);
                 lua_pop(L.get(), 1);
@@ -113,12 +113,13 @@ public:
                 luaL_requiref(L.get(), "math", luaopen_math, 1);
                 lua_pop(L.get(), 1);
                 break;
-#if SOL_LUA_VERSION > 510
             case lib::bit32:
+#if SOL_LUA_VERSION > 510
                 luaL_requiref(L.get(), "bit32", luaopen_bit32, 1);
                 lua_pop(L.get(), 1);
-                break;
+#else
 #endif // Lua 5.2+ only
+                break;
             case lib::io:
                 luaL_requiref(L.get(), "io", luaopen_io, 1);
                 lua_pop(L.get(), 1);

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -95,13 +95,13 @@ public:
                 luaL_requiref(L.get(), "package", luaopen_package, 1);
                 lua_pop(L.get(), 1);
                 break;
-            case lib::coroutine:
 #if SOL_LUA_VERSION > 501
+		  case lib::coroutine:
                 luaL_requiref(L.get(), "coroutine", luaopen_coroutine, 1);
                 lua_pop(L.get(), 1);
-#endif // Lua 5.2+ only
                 break;
-            case lib::string:
+#endif // Lua 5.2+ only
+		  case lib::string:
                 luaL_requiref(L.get(), "string", luaopen_string, 1);
                 lua_pop(L.get(), 1);
                 break;

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -58,7 +58,7 @@ public:
     state(lua_CFunction panic = detail::atpanic):
     L(luaL_newstate(), lua_close),
     reg(L.get(), LUA_REGISTRYINDEX),
-#if SOL_LUA_VERSION < 503
+#if SOL_LUA_VERSION < 502
     // Global table is just a special index
     global(L.get(), LUA_GLOBALSINDEX) {
 #else

--- a/sol/state.hpp
+++ b/sol/state.hpp
@@ -55,7 +55,7 @@ private:
     table reg;
     table global;
 public:
-    state():
+    state(lua_CFunction panic = detail::atpanic):
     L(luaL_newstate(), lua_close),
     reg(L.get(), LUA_REGISTRYINDEX),
 #if SOL_LUA_VERSION < 503
@@ -65,7 +65,7 @@ public:
     // Global tables are stored in the environment/registry table
     global(reg.get<table>(LUA_RIDX_GLOBALS)) {
 #endif // Lua 5.2
-        lua_atpanic(L.get(), detail::atpanic);
+        set_panic(panic);
     }
 
     lua_State* lua_state() const {
@@ -233,6 +233,10 @@ public:
 
     table registry() const {
         return reg;
+    }
+
+    void set_panic(lua_CFunction panic){
+        lua_atpanic(L.get(), panic);
     }
 
     template<typename T>

--- a/sol/table.hpp
+++ b/sol/table.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/table.hpp
+++ b/sol/table.hpp
@@ -58,7 +58,7 @@ public:
 
     template<typename... Ret, typename... Keys>
     stack::get_return<Ret...> get( Keys&&... keys ) const {
-	    return tuple_get(types<Ret...>(), build_indices<sizeof...(Ret)>(), std::tie(keys...));
+        return tuple_get(types<Ret...>(), build_indices<sizeof...(Ret)>(), std::tie(keys...));
     }
 
     template<typename T, typename U>
@@ -118,12 +118,12 @@ public:
 
     template<typename T>
     proxy<table, T> operator[]( T&& key ) {
-	    return proxy<table, T>( *this, std::forward<T>( key ) );
+        return proxy<table, T>( *this, std::forward<T>( key ) );
     }
 
     template<typename T>
     proxy<const table, T> operator[]( T&& key ) const {
-	    return proxy<const table, T>( *this, std::forward<T>( key ) );
+        return proxy<const table, T>( *this, std::forward<T>( key ) );
     }
 
     void pop(int n = 1) const noexcept {

--- a/sol/table.hpp
+++ b/sol/table.hpp
@@ -31,7 +31,7 @@ namespace sol {
 class table : public reference {
     friend class state;
     template<typename T, typename U>
-    typename stack::get_return<T>::type single_get(U&& key) const {
+    auto single_get(U&& key) const -> decltype(stack::get<T>(nullptr, 0)) {
         push();
         stack::push(state(), std::forward<U>(key));
         lua_gettable(state(), -2);

--- a/sol/table.hpp
+++ b/sol/table.hpp
@@ -42,13 +42,13 @@ class table : public reference {
     }
 
     template<typename Keys, typename... Ret, std::size_t... I>
-    typename return_type<typename stack::get_return<Ret>::type...>::type tuple_get(types<Ret...>, indices<I...>, Keys&& keys) const {
+    auto tuple_get(types<Ret...>, indices<I...>, Keys&& keys) const -> decltype(std::make_tuple(single_get<Ret>(std::get<I>(keys))...)) {
         return std::make_tuple(single_get<Ret>(std::get<I>(keys))...);
     }
 
-    template<typename Keys, typename Ret>
-    typename stack::get_return<Ret>::type tuple_get(types<Ret>, indices<0>, Keys&& keys) const {
-        return single_get<Ret>(std::get<0>(keys));
+    template<typename Keys, std::size_t I, typename Ret>
+    auto tuple_get(types<Ret>, indices<I>, Keys&& keys) const -> decltype(single_get<Ret>(std::get<I>(keys))) {
+        return single_get<Ret>(std::get<I>(keys));
     }
 
 public:
@@ -58,9 +58,9 @@ public:
     }
 
     template<typename... Ret, typename... Keys>
-    typename return_type<typename stack::get_return<Ret>::type...>::type get(Keys&&... keys) const {
+    auto get(Keys&&... keys) const -> decltype(tuple_get(types<Ret...>(), types<Ret...>(), std::tie(std::forward<Keys>(keys)...))) {
         types<Ret...> tr;
-        return tuple_get(tr, tr, std::make_tuple(std::forward<Keys>(keys)...));
+        return tuple_get(tr, tr, std::tie(std::forward<Keys>(keys)...));
     }
 
     template<typename T, typename U>

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -122,8 +122,11 @@ struct return_type<> {
     typedef void type;
 };
 
+template <typename Empty, typename... Tn>
+using ReturnTypeOr = typename std::conditional<(sizeof...(Tn) < 1), Empty, typename return_type<Tn...>::type>::type;
+
 template <typename... Tn>
-using ReturnType = typename return_type<Tn...>::type;
+using ReturnType = ReturnTypeOr<void, Tn...>;
 
 namespace detail {
 

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -286,8 +286,8 @@ struct member_traits : detail::member_traits<Signature> {
 
 struct has_begin_end_impl {
     template<typename T, typename U = Unqualified<T>,
-                         typename B = decltype(std::declval<U&>().begin()),
-                         typename E = decltype(std::declval<U&>().end())>
+        typename B = decltype(std::declval<U&>().begin()),
+        typename E = decltype(std::declval<U&>().end())>
     static std::true_type test(int);
 
     template<typename...>
@@ -299,9 +299,9 @@ struct has_begin_end : decltype(has_begin_end_impl::test<T>(0)) {};
 
 struct has_key_value_pair_impl {
     template<typename T, typename U = Unqualified<T>,
-             typename V = typename U::value_type,
-             typename F = decltype(std::declval<V&>().first),
-             typename S = decltype(std::declval<V&>().second)>
+        typename V = typename U::value_type,
+        typename F = decltype(std::declval<V&>().first),
+        typename S = decltype(std::declval<V&>().second)>
     static std::true_type test(int);
 
     template<typename...>

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -118,9 +118,12 @@ struct return_type<T> {
 };
 
 template<>
-struct return_type<> : types<>{
+struct return_type<> {
     typedef void type;
 };
+
+template <typename... Tn>
+using ReturnType = typename return_type<Tn...>::type;
 
 namespace detail {
 

--- a/sol/tuple.hpp
+++ b/sol/tuple.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -62,6 +62,14 @@ enum class call_syntax {
     colon = 1
 };
 
+enum class call_error : int {
+	ok = LUA_OK,
+	runtime = LUA_ERRRUN,
+	memory = LUA_ERRMEM,
+	handler = LUA_ERRERR,
+	gc = LUA_ERRGCMM
+};
+
 enum class type : int {
     none          = LUA_TNONE,
     nil           = LUA_TNIL,

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -118,64 +118,43 @@ class function;
 class object;
 
 template <typename T, typename = void>
-struct lua_type_of : std::integral_constant<type, type::userdata> {
-
-};
+struct lua_type_of : std::integral_constant<type, type::userdata> {};
 
 template <>
-struct lua_type_of<std::string> : std::integral_constant<type, type::string> {
-
-};
+struct lua_type_of<std::string> : std::integral_constant<type, type::string> {};
 
 template <std::size_t N>
-struct lua_type_of<char[N]> : std::integral_constant<type, type::string> {
-
-};
+struct lua_type_of<char[N]> : std::integral_constant<type, type::string> {};
 
 template <>
-struct lua_type_of<const char*> : std::integral_constant<type, type::string> {
-
-};
+struct lua_type_of<const char*> : std::integral_constant<type, type::string> {};
 
 template <>
-struct lua_type_of<bool> : std::integral_constant<type, type::boolean> {
-
-};
+struct lua_type_of<bool> : std::integral_constant<type, type::boolean> {};
 
 template <>
-struct lua_type_of<nil_t> : std::integral_constant<type, type::nil> {
-
-};
+struct lua_type_of<nil_t> : std::integral_constant<type, type::nil> {};
 
 template <>
-struct lua_type_of<table> : std::integral_constant<type, type::table> {
-
-};
+struct lua_type_of<table> : std::integral_constant<type, type::table> {};
 
 template <>
-struct lua_type_of<object> : std::integral_constant<type, type::poly> {
-
-};
+struct lua_type_of<object> : std::integral_constant<type, type::poly> {};
 
 template <>
-struct lua_type_of<light_userdata> : std::integral_constant<type, type::lightuserdata> {
-
-};
+struct lua_type_of<light_userdata> : std::integral_constant<type, type::lightuserdata> {};
 
 template <>
-struct lua_type_of<function> : std::integral_constant<type, type::function> {
+struct lua_type_of<function> : std::integral_constant<type, type::function> {};
 
-};
+template <typename Signature>
+struct lua_type_of<std::function<Signature>> : std::integral_constant<type, type::function>{};
 
 template <typename T>
-struct lua_type_of<T*> : std::integral_constant<type, type::userdata> {
-
-};
+struct lua_type_of<T*> : std::integral_constant<type, type::userdata> {};
 
 template <typename T>
-struct lua_type_of<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> : std::integral_constant<type, type::number> {
-
-};
+struct lua_type_of<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> : std::integral_constant<type, type::number> {};
 
 template<typename T>
 inline type type_of() {

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -73,7 +73,7 @@ enum class type : int {
     userdata      = LUA_TUSERDATA,
     lightuserdata = LUA_TLIGHTUSERDATA,
     table         = LUA_TTABLE,
-    poly          = none   | nil     | string   | number   | thread       |
+    poly          = none   | nil     | string   | number   | thread          |
                     table  | boolean | function | userdata | lightuserdata
 };
 
@@ -96,14 +96,14 @@ inline void type_error(lua_State* L, type expected, type actual) {
 
 inline void type_assert(lua_State* L, int index, type expected, type actual) {
     if (expected != type::poly && expected != actual) {
-        type_panic(L, index, expected, actual);
+           type_panic(L, index, expected, actual);
     }
 }
 
 inline void type_assert(lua_State* L, int index, type expected) {
     int actual = lua_type(L, index);
     if(expected != type::poly && static_cast<int>(expected) != actual) {
-        type_error(L, static_cast<int>(expected), actual);
+           type_error(L, static_cast<int>(expected), actual);
     }
 }
 

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -95,9 +95,9 @@ inline void type_error(lua_State* L, type expected, type actual) {
 }
 
 inline void type_assert(lua_State* L, int index, type expected, type actual) {
-	if (expected != type::poly && expected != actual) {
-		type_panic(L, index, expected, actual);
-	}
+    if (expected != type::poly && expected != actual) {
+        type_panic(L, index, expected, actual);
+    }
 }
 
 inline void type_assert(lua_State* L, int index, type expected) {

--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -22,9 +22,9 @@
 #ifndef SOL_TYPES_HPP
 #define SOL_TYPES_HPP
 
-#include <lua.hpp>
-#include <string>
+#include "compatibility.hpp"
 #include "traits.hpp"
+#include <string>
 
 namespace sol {
 struct nil_t {};

--- a/sol/usertype.hpp
+++ b/sol/usertype.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/sol/usertype.hpp
+++ b/sol/usertype.hpp
@@ -358,11 +358,11 @@ public:
         // but leave the regular T table on last
         // so it can be linked to a type for usage with `.new(...)` or `:new(...)`
         push_metatable(L, usertype_traits<T*>::metatable,
-                       metafunctions, ptrmetafunctiontable);
+            metafunctions, ptrmetafunctiontable);
         lua_pop(L, 1);
 
         push_metatable(L, usertype_traits<T>::metatable,
-                       metafunctions, metafunctiontable);
+            metafunctions, metafunctiontable);
         set_global_deleter(L);
         return 1;
     }

--- a/sol/usertype.hpp
+++ b/sol/usertype.hpp
@@ -269,8 +269,8 @@ private:
             std::unique_ptr<base_function> ptr(nullptr);
             if(indexmetamethod != meta_variable_names.end()) {
                 auto idxptr = detail::make_unique<usertype_indexing_function<function_type, T>>(name, func);
-			 std::ptrdiff_t idxvalue = std::distance(meta_variable_names.begin(), indexmetamethod);
-			 switch(idxvalue) {
+                std::ptrdiff_t idxvalue = std::distance(meta_variable_names.begin(), indexmetamethod);
+                switch(idxvalue) {
                 case 0:
                     index = &(idxptr->functions);
                     break;

--- a/sol/usertype.hpp
+++ b/sol/usertype.hpp
@@ -269,7 +269,8 @@ private:
             std::unique_ptr<base_function> ptr(nullptr);
             if(indexmetamethod != meta_variable_names.end()) {
                 auto idxptr = detail::make_unique<usertype_indexing_function<function_type, T>>(name, func);
-                switch(std::distance(indexmetamethod, meta_variable_names.end())) {
+			 std::ptrdiff_t idxvalue = std::distance(meta_variable_names.begin(), indexmetamethod);
+			 switch(idxvalue) {
                 case 0:
                     index = &(idxptr->functions);
                     break;

--- a/sol/usertype_traits.hpp
+++ b/sol/usertype_traits.hpp
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 
-// Copyright (c) 2013 Danny Y., Rapptz
+// Copyright (c) 2013-2015 Danny Y., Rapptz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/tests.cpp
+++ b/tests.cpp
@@ -445,7 +445,7 @@ TEST_CASE("functions/overloaded", "Check if overloaded function resolution templ
     lua.open_libraries(sol::lib::base);
 
     lua.set_function("non_overloaded", non_overloaded);
-    REQUIRE_NOTHROW(lua.script("x = non_overloaded(1)\nprint(x)"));
+    REQUIRE_NOTHROW(lua.script("x = non_overloaded(1, 2, 3)\nprint(x)"));
 
     /*
     // Cannot reasonably support: clang++ refuses to try enough
@@ -466,7 +466,7 @@ TEST_CASE("functions/overloaded", "Check if overloaded function resolution templ
     REQUIRE_NOTHROW(lua.script("print(overloaded(1, 2))"));
 
     lua.set_function<int(int, int, int)>("overloaded", overloaded);
-    REQUIRE_NOTHROW(lua.script("print(overloaded(1, 2))"));
+    REQUIRE_NOTHROW(lua.script("print(overloaded(1, 2, 3))"));
 }
 
 TEST_CASE("functions/return_order_and_multi_get", "Check if return order is in the same reading order specified in Lua") {

--- a/tests.cpp
+++ b/tests.cpp
@@ -1009,7 +1009,7 @@ TEST_CASE( "functions/sol::function_result", "Function result should be the beef
     // Some function; just using a lambda to be cheap
     auto doom = []() {
         // Bypasses handler function: puts information directly into lua error
-        throw std::exception( errormessage1 );
+        throw std::runtime_error( errormessage1 );
     };
     auto luadoom = [&lua]() {
         // Does not bypass error function, will call it

--- a/tests.cpp
+++ b/tests.cpp
@@ -472,20 +472,24 @@ TEST_CASE("functions/overloaded", "Check if overloaded function resolution templ
 
 TEST_CASE("functions/return_order_and_multi_get", "Check if return order is in the same reading order specified in Lua") {
     const static std::tuple<int, int, int> triple = std::make_tuple(10, 11, 12);
+    const static std::tuple<int, float> paired = std::make_tuple(10, 10.f);
     sol::state lua;
     lua.set_function("f", [] {
         return std::make_tuple(10, 11, 12);
-    });
+    } );
+    int a = 0;
+    lua.set_function( "h", []() {
+        return std::make_tuple( 10, 10.0f );
+    } );
     lua.script("function g() return 10, 11, 12 end\nx,y,z = g()");
     auto tcpp = lua.get<sol::function>("f").call<int, int, int>();
-    auto tlua = lua.get<sol::function>("g").call<int, int, int>();
-    auto tluaget = lua.get<int, int, int>("x", "y", "z");
-    std::cout << "cpp: " << std::get<0>(tcpp) << ',' << std::get<1>(tcpp) << ',' << std::get<2>(tcpp) << std::endl;
-    std::cout << "lua: " << std::get<0>(tlua) << ',' << std::get<1>(tlua) << ',' << std::get<2>(tlua) << std::endl;
-    std::cout << "lua xyz: " << lua.get<int>("x") << ',' << lua.get<int>("y") << ',' << lua.get<int>("z") << std::endl;
+    auto tlua = lua.get<sol::function>( "g" ).call<int, int, int>();
+    auto tcpp2 = lua.get<sol::function>( "h" ).call<int, float>();
+    auto tluaget = lua.get<int, int, int>( "x", "y", "z" );
     REQUIRE(tcpp == triple);
     REQUIRE(tlua == triple);
     REQUIRE(tluaget == triple);
+    REQUIRE(tcpp2 == paired);
 }
 
 TEST_CASE("functions/deducing_return_order_and_multi_get", "Check if return order is in the same reading order specified in Lua, with regular deducing calls") {

--- a/tests.cpp
+++ b/tests.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN
+#define SOL_CHECK_ARGUMENTS
 #include <catch.hpp>
 #include <sol.hpp>
 #include <vector>

--- a/tests.cpp
+++ b/tests.cpp
@@ -955,3 +955,18 @@ TEST_CASE("references/get-set", "properly get and set with std::ref semantics. N
     // Reference should point back to the same type.
     REQUIRE(rvar.boop == ref_var.boop);
 }
+
+TEST_CASE("interop/null-to-nil-and-back", "nil should be the given type when a pointer from C++ is returned as nullptr, and nil should result in nullptr in connected C++ code") {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base);
+
+    lua.set_function("lol", []() -> int* {
+        return nullptr;
+    });
+    lua.set_function("rofl", [](int* x) {
+        std::cout << x << std::endl;
+    });
+    REQUIRE_NOTHROW(lua.script("x = lol()\n"
+        "rofl(x)\n"
+        "assert(x == nil)"));
+}


### PR DESCRIPTION
This pull request adds support for Lua 5.1 through a compatibility layer as per the question in Issue #56. This also means LuaJIT can now work with sol.

Note that luajit is much less kinda that vanilla Lua and mistakes such as not passing the correct number of parameters and the like is punished with segfaults.

This PR also updates the copyright headers and fixes some tests to prevent luajit program termination because of badly written lua code.
