### PR TITLE
to_lua/from_lua (with love)

### DIFF
--- a/sol/stack.hpp
+++ b/sol/stack.hpp
@@ -344,14 +344,19 @@ struct pusher {
        return ref.push();
     }
 
-    template<typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>
-    static int push(lua_State* L, T& t) {
-        return detail::push_userdata<U>(L, usertype_traits<T>::metatable, t);
+    template<typename Arg, typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>
+    static int push(lua_State* L, Arg&& a) {
+        return push_to_lua(has_to_lua<T>(), L, std::forward<Arg>(arg));
     }
 
-    template<typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>
-    static int push(lua_State* L, T&& t) {
-        return detail::push_userdata<U>(L, usertype_traits<T>::metatable, std::move(t));
+    template<typename Arg, typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>
+    static int push_to_lua(std::true_type, lua_State* L, Arg&& a) {
+        return to_lua(L, std::forward<Arg>(a));
+    }
+
+    template<typename Arg, typename U = Unqualified<T>, EnableIf<Not<has_begin_end<U>>, Not<std::is_base_of<reference, U>>, Not<std::is_integral<U>>, Not<std::is_floating_point<U>>> = 0>
+    static int push_to_lua(lua_State* L, Arg&& arg) {
+        return detail::push_userdata<U>(L, usertype_traits<T>::metatable, std::forward<Arg>(arg)));
     }
 };
 

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -123,6 +123,13 @@ struct return_type<> : types<>{
 };
 
 namespace detail {
+struct has_to_lua_impl {
+    template<typename T, typename U = decltype(to_lua(nullptr, std::declval<T>()))>
+    static std::is_integral<U> test(int);
+
+    template<typename...>
+    static std::false_type test(...);
+};
 
 template<typename T, bool isclass = std::is_class<Unqualified<T>>::value>
 struct is_function_impl : std::is_function<typename std::remove_pointer<T>::type> {};
@@ -162,6 +169,9 @@ struct has_deducible_signature : detail::check_deducible_signature<F>::type { };
 
 template<typename T>
 using has_deducible_signature_t = typename has_deducible_signature<T>::type;
+
+template<typename T>
+struct has_to_lua : decltype(detail::has_to_lua_impl::test<T>(0)) {};
 
 template<typename T>
 struct Function : Bool<detail::is_function_impl<T>::value> {};

--- a/sol/traits.hpp
+++ b/sol/traits.hpp
@@ -131,6 +131,22 @@ struct has_to_lua_impl {
     static std::false_type test(...);
 };
 
+struct has_from_lua_impl {
+    template<typename T, typename U = decltype(from_lua(types<T>(), nullptr, -1))>
+    static std::is_convertible<U, T> test(int);
+
+    template<typename...>
+    static std::false_type test(...);
+};
+
+struct has_check_lua_impl {
+    template<typename T, typename U = decltype(check_lua(types<T>(), nullptr, -1))>
+    static std::is_convertible<U, bool> test(int);
+
+    template<typename...>
+    static std::false_type test(...);
+};
+
 template<typename T, bool isclass = std::is_class<Unqualified<T>>::value>
 struct is_function_impl : std::is_function<typename std::remove_pointer<T>::type> {};
 
@@ -172,6 +188,12 @@ using has_deducible_signature_t = typename has_deducible_signature<T>::type;
 
 template<typename T>
 struct has_to_lua : decltype(detail::has_to_lua_impl::test<T>(0)) {};
+
+template<typename T>
+struct has_from_lua : decltype(detail::has_from_lua_impl::test<T>(0)) {};
+
+template<typename T>
+struct has_check_lua : decltype(detail::has_check_lua_impl::test<T>(0)) {};
 
 template<typename T>
 struct Function : Bool<detail::is_function_impl<T>::value> {};


### PR DESCRIPTION
This pull requests vastly simplifies the "plug in" architecture by allowing a user to define three functions to hook into the existing lua system:

`int to_lua( lua_State* L, T&& item )`
`SomeReturn from_lua( types<T>, lua_State* L, int index )`
`bool check_lua( types<T>, lua_State* L, int index )`

It's mostly an experimental feature, and I do not like the interface for `from_lua` and `check_lua`, since we have to take an overload-resolving argument `types<T>` in order to properly SFINAE if such a function exists (and prevent ambiguous overloads if you want to write such a function for multiple types).

`to_lua`, however, is done quite nicely and works out pretty well (tests also pass for the branch).
