### PR TITLE
Unable to register a table

### DIFF
--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -46,7 +46,7 @@ public:
         luaL_unref(L, LUA_REGISTRYINDEX, ref);
     }
 
-    void push() const noexcept {
+    int push() const noexcept {
         lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
 	return 1;
     }

--- a/sol/reference.hpp
+++ b/sol/reference.hpp
@@ -48,6 +48,7 @@ public:
 
     void push() const noexcept {
         lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+	return 1;
     }
 
     reference(reference&& o) noexcept {


### PR DESCRIPTION
The following piece of code was not compiling

```
sol::state state;
sol::table some_table = state.create_table();
state.set("some_table", some_table);
```

The compilation error which was fixed

```
Users/andreiperciun/Developer/paper-rl/build/sources/libraries/sol/sol_develop/src/project-sol/sol/stack.hpp:344:15: error: cannot initialize return object of type 'int' with an rvalue of type 'void'
       return ref.push();
              ^~~~~~~~~~
/Users/andreiperciun/Developer/paper-rl/build/sources/libraries/sol/sol_develop/src/project-sol/sol/stack.hpp:97:37: note: in instantiation of function template specialization
      'sol::stack::pusher<sol::table, void>::push<sol::table, 0>' requested here
    return pusher<Unqualified<T>>{}.push(L, std::forward<T>(t), std::forward<Args>(args)...);
                                    ^
/Users/andreiperciun/Developer/paper-rl/build/sources/libraries/sol/sol_develop/src/project-sol/sol/table.hpp:70:16: note: in instantiation of function template specialization
      'sol::stack::push<sol::table &>' requested here
        stack::push(state(), std::forward<U>(value));
               ^
/Users/andreiperciun/Developer/paper-rl/build/sources/libraries/sol/sol_develop/src/project-sol/sol/state.hpp:147:16: note: in instantiation of function template specialization
      'sol::table::set<char const (&)[8], sol::table &>' requested here
        global.set(std::forward<T>(key), std::forward<U>(value));
```
