### PR TITLE
#define LUA_COMPAT_APIINTCASTS to support lua 5.3

### DIFF
--- a/sol/types.hpp
+++ b/sol/types.hpp
@@ -22,6 +22,7 @@
 #ifndef SOL_TYPES_HPP
 #define SOL_TYPES_HPP
 
+#define LUA_COMPAT_APIINTCASTS
 #include <lua.hpp>
 #include <string>
 #include "traits.hpp"


### PR DESCRIPTION
LUA_COMPAT_APIINTCASTS macro is required to enable lua_tounsigned() in lua 5.3 or else stack.hpp won't compile
